### PR TITLE
Fix: sauvegarde des prérequis texte des notes de frais

### DIFF
--- a/app/Http/Controllers/API/ExpenseSheetController.php
+++ b/app/Http/Controllers/API/ExpenseSheetController.php
@@ -104,6 +104,7 @@ class ExpenseSheetController extends BaseController
                 'costs.*.date' => 'required|date',
                 'costs.*.requirements' => 'nullable|array',
                 'costs.*.requirements.*.file' => 'nullable|file|mimes:pdf,jpg,jpeg,png,gif,webp,heic,heif|max:20480',
+                'costs.*.requirements.*.value' => 'nullable|string',
                 'department_id' => 'required|exists:departments,id',
                 'target_user_id' => 'nullable|exists:users,id',
                 'is_draft' => 'required|boolean',
@@ -433,6 +434,7 @@ class ExpenseSheetController extends BaseController
                 'costs.*.id' => 'nullable|exists:expense_sheet_costs,id',
                 'costs.*.requirements' => 'nullable|array',
                 'costs.*.requirements.*.file' => 'nullable|file|mimes:pdf,jpg,jpeg,png,gif,webp,heic,heif|max:20480',
+                'costs.*.requirements.*.value' => 'nullable|string',
                 'department_id' => 'required|exists:departments,id',
                 'is_draft' => 'required|boolean',
             ], [

--- a/app/Http/Controllers/ExpenseSheetController.php
+++ b/app/Http/Controllers/ExpenseSheetController.php
@@ -150,6 +150,7 @@ class ExpenseSheetController extends Controller
                     'costs.*.date' => 'required|date',
                     'costs.*.requirements' => 'nullable|array',
                     'costs.*.requirements.*.file' => 'nullable|file|mimes:pdf,jpg,jpeg,png,gif,webp,heic,heif|max:20480',
+                    'costs.*.requirements.*.value' => 'nullable|string',
                     'department_id' => 'required|exists:departments,id',
                     'target_user_id' => 'nullable|exists:users,id',
                     'is_draft' => 'required|boolean',
@@ -521,6 +522,8 @@ class ExpenseSheetController extends Controller
             'costs.*.date' => 'required|date',
             'costs.*.requirements' => 'nullable|array',
             'costs.*.requirements.*.file' => 'nullable|file|mimes:pdf,jpg,jpeg,png,gif,webp,heic,heif|max:20480',
+            'costs.*.requirements.*.value' => 'nullable|string',
+            'costs.*.requirements.*.existing_file' => 'nullable|string',
         ], [
             'costs.*.requirements.*.file.mimes' => 'Les annexes doivent être au format PDF ou image (JPG, PNG, GIF, WEBP, HEIC).',
             'costs.*.requirements.*.file.max' => 'Chaque annexe ne peut pas dépasser 20 Mo.',

--- a/tests/Feature/ExpenseSheetTextRequirementTest.php
+++ b/tests/Feature/ExpenseSheetTextRequirementTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\ExpenseSheetCost;
+use App\Models\Form;
+use App\Models\FormCost;
+use App\Models\FormCostRemboursiementRate;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ExpenseSheetTextRequirementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function bootstrap(): array
+    {
+        Notification::fake();
+        Storage::fake('public');
+
+        $department = Department::factory()->create();
+        $user = User::factory()->create(['is_admin' => false]);
+        $department->users()->attach($user->id);
+
+        $form = Form::factory()->create();
+        $formCost = new FormCost;
+        $formCost->name = 'Frais avec prérequis texte';
+        $formCost->description = 'Coût avec prérequis texte';
+        $formCost->type = 'fixed';
+        $formCost->form_id = $form->id;
+        $formCost->save();
+        $rate = new FormCostRemboursiementRate;
+        $rate->form_cost_id = $formCost->id;
+        $rate->start_date = '2026-01-01';
+        $rate->end_date = null;
+        $rate->value = 25;
+        $rate->save();
+
+        return compact('department', 'user', 'form', 'formCost');
+    }
+
+    public function test_text_requirement_value_is_persisted(): void
+    {
+        $context = $this->bootstrap();
+
+        $payload = [
+            'department_id' => $context['department']->id,
+            'is_draft' => 0,
+            'costs' => [
+                [
+                    'cost_id' => $context['formCost']->id,
+                    'data' => ['paidAmount' => 25],
+                    'date' => '2026-05-01',
+                    'requirements' => [
+                        'Numéro de note' => ['value' => 'NDF-2026-001'],
+                    ],
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($context['user'])
+            ->post("/expense-sheet/{$context['form']->id}", $payload);
+
+        $response->assertSessionHasNoErrors();
+        $this->assertDatabaseCount('expense_sheets', 1);
+
+        $cost = ExpenseSheetCost::firstOrFail();
+        $requirements = is_string($cost->requirements)
+            ? json_decode($cost->requirements, true)
+            : $cost->requirements;
+
+        $this->assertArrayHasKey('Numéro de note', $requirements);
+        $this->assertSame('NDF-2026-001', $requirements['Numéro de note']['value']);
+    }
+}


### PR DESCRIPTION
La règle de validation n'autorisait que les prérequis de type fichier, ce qui faisait supprimer silencieusement la clé 'value' (texte) par Laravel. Ajout de la règle de validation pour les valeurs texte sur les contrôleurs web et API (store + update).