### PR TITLE
Répartition multi-dates et duplication des coûts (création & édition)

### DIFF
--- a/resources/js/pages/expenseSheet/Create.vue
+++ b/resources/js/pages/expenseSheet/Create.vue
@@ -53,6 +53,16 @@
                 >
                     <!-- Boutons d'action -->
                     <div class="absolute right-2 top-2 flex gap-1 sm:gap-2">
+                        <Button
+                            v-if="canUseMultiDate(cost)"
+                            variant="ghost"
+                            size="icon"
+                            class="h-8 w-8 sm:h-10 sm:w-10 text-primary"
+                            title="Répartir ce coût sur plusieurs dates"
+                            @click="openMultiDateDialog(index)"
+                        >
+                            <CalendarPlusIcon class="h-4 w-4 sm:h-5 sm:w-5" />
+                        </Button>
                         <Button variant="ghost" size="icon" class="h-8 w-8 sm:h-10 sm:w-10 text-primary" @click="openDuplicateDialog(index)">
                             <CopyIcon class="h-4 w-4 sm:h-5 sm:w-5" />
                         </Button>
@@ -170,6 +180,43 @@
                 </DialogFooter>
             </DialogContent>
         </Dialog>
+
+        <!-- Modal de répartition sur plusieurs dates -->
+        <Dialog v-model:open="multiDateDialog.isOpen">
+            <DialogContent class="max-w-[90vw] sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle class="text-base sm:text-lg">Répartir sur plusieurs dates</DialogTitle>
+                    <DialogDescription class="text-xs sm:text-sm">
+                        Sélectionnez les dates auxquelles vous avez effectué "{{ multiDateDialog.costName }}". Une copie du coût sera créée pour chaque date.
+                    </DialogDescription>
+                </DialogHeader>
+                <div class="max-h-[50vh] space-y-2 overflow-y-auto py-3 sm:py-4">
+                    <div v-for="(d, i) in multiDateDialog.dates" :key="i" class="flex items-center gap-2">
+                        <input
+                            type="date"
+                            v-model="multiDateDialog.dates[i]"
+                            class="w-full rounded border border-border bg-background p-1.5 sm:p-2 text-sm sm:text-base text-foreground"
+                        />
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            class="h-8 w-8 shrink-0 text-destructive"
+                            :disabled="multiDateDialog.dates.length <= 1"
+                            @click="removeMultiDateRow(i)"
+                        >
+                            <Trash2Icon class="h-4 w-4" />
+                        </Button>
+                    </div>
+                    <Button variant="outline" size="sm" class="w-full" @click="addMultiDateRow">
+                        <PlusIcon class="mr-2 h-4 w-4" /> Ajouter une date
+                    </Button>
+                </div>
+                <DialogFooter class="flex-col xs:flex-row gap-2">
+                    <Button variant="outline" @click="multiDateDialog.isOpen = false" class="w-full xs:w-auto">Annuler</Button>
+                    <Button @click="confirmMultiDate" class="w-full xs:w-auto">Ajouter les coûts</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
     </AppLayout>
 </template>
 
@@ -181,7 +228,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { Head, useForm } from '@inertiajs/vue3';
-import { CopyIcon, Loader2Icon, Trash2Icon } from 'lucide-vue-next';
+import { CalendarPlusIcon, CopyIcon, Loader2Icon, PlusIcon, Trash2Icon } from 'lucide-vue-next';
 import { computed, onMounted, ref, watch } from 'vue';
 
 import CostPicker from '@/components/expense/CostPicker.vue';
@@ -337,6 +384,87 @@ const confirmDuplicate = () => {
 
     // Fermer le modal
     duplicateDialog.value.isOpen = false;
+};
+
+// Répartition d'un coût sur plusieurs dates
+// Disponible uniquement pour les coûts sans prérequis (annexe ou texte)
+// et remboursés au pourcentage ou au montant fixe.
+const canUseMultiDate = (cost) => !cost.requirements?.length && (cost.type === 'percentage' || cost.type === 'fixed');
+
+const multiDateDialog = ref({
+    isOpen: false,
+    costIndex: -1,
+    costName: '',
+    dates: [],
+});
+
+const openMultiDateDialog = (index) => {
+    const cost = selectedCosts.value[index];
+    const today = new Date().toISOString().split('T')[0];
+    multiDateDialog.value = {
+        isOpen: true,
+        costIndex: index,
+        costName: cost.name,
+        dates: [today],
+    };
+};
+
+const addMultiDateRow = () => {
+    const today = new Date().toISOString().split('T')[0];
+    multiDateDialog.value.dates.push(today);
+};
+
+const removeMultiDateRow = (i) => {
+    multiDateDialog.value.dates.splice(i, 1);
+};
+
+const buildCostDataForDate = (cost, sourceData, date) => {
+    const rate = getActiveRate(cost, date);
+    const data = {
+        date,
+        kmData: { ...sourceData.kmData },
+        percentageData: {
+            paidAmount: sourceData.percentageData?.paidAmount ?? null,
+            percentage: rate,
+            reimbursedAmount: 0,
+        },
+        requirements: {},
+        fixedAmount: rate,
+    };
+
+    if (cost.type === 'percentage') {
+        const paid = data.percentageData.paidAmount;
+        if (paid !== null && typeof paid !== 'undefined' && paid !== '') {
+            data.percentageData.reimbursedAmount = (paid * rate) / 100;
+        }
+    }
+
+    return data;
+};
+
+const confirmMultiDate = () => {
+    const { costIndex, dates } = multiDateDialog.value;
+
+    const validDates = [...new Set(dates.filter((d) => !!d))];
+    if (!validDates.length) {
+        multiDateDialog.value.isOpen = false;
+        return;
+    }
+
+    if (selectedCosts.value.length + validDates.length > 30) {
+        alert(`Vous ne pouvez pas ajouter ${validDates.length} coûts. Maximum 30 coûts au total.`);
+        return;
+    }
+
+    const originalCost = selectedCosts.value[costIndex];
+    const originalData = costData.value[costIndex];
+
+    validDates.forEach((date) => {
+        selectedCosts.value.push(originalCost);
+        costData.value.push(buildCostDataForDate(originalCost, originalData, date));
+    });
+
+    multiDateDialog.value.isOpen = false;
 };
 
 const submitted = ref(false);

--- a/resources/js/pages/expenseSheet/Create.vue
+++ b/resources/js/pages/expenseSheet/Create.vue
@@ -387,9 +387,10 @@ const confirmDuplicate = () => {
 };
 
 // Répartition d'un coût sur plusieurs dates
-// Disponible uniquement pour les coûts sans prérequis (annexe ou texte)
-// et remboursés au pourcentage ou au montant fixe.
-const canUseMultiDate = (cost) => !cost.requirements?.length && (cost.type === 'percentage' || cost.type === 'fixed');
+// Disponible pour les coûts sans annexe (prérequis de type fichier) : km,
+// pourcentage et fixe. Les éventuels prérequis texte sont recopiés sur chaque date.
+const hasAnnexeRequirement = (cost) => (cost.requirements || []).some((r) => r.type === 'file');
+const canUseMultiDate = (cost) => !hasAnnexeRequirement(cost);
 
 const multiDateDialog = ref({
     isOpen: false,
@@ -420,15 +421,24 @@ const removeMultiDateRow = (i) => {
 
 const buildCostDataForDate = (cost, sourceData, date) => {
     const rate = getActiveRate(cost, date);
+
+    // Recopie des prérequis texte (les annexes sont exclues via canUseMultiDate)
+    const requirements = {};
+    Object.entries(sourceData.requirements || {}).forEach(([key, value]) => {
+        if (!(value instanceof File)) {
+            requirements[key] = value;
+        }
+    });
+
     const data = {
         date,
-        kmData: { ...sourceData.kmData },
+        kmData: JSON.parse(JSON.stringify(sourceData.kmData || {})),
         percentageData: {
             paidAmount: sourceData.percentageData?.paidAmount ?? null,
             percentage: rate,
             reimbursedAmount: 0,
         },
-        requirements: {},
+        requirements,
         fixedAmount: rate,
     };
 

--- a/resources/js/pages/expenseSheet/Create.vue
+++ b/resources/js/pages/expenseSheet/Create.vue
@@ -190,26 +190,42 @@
                         Sélectionnez les dates auxquelles vous avez effectué "{{ multiDateDialog.costName }}". Une copie du coût sera créée pour chaque date.
                     </DialogDescription>
                 </DialogHeader>
-                <div class="max-h-[50vh] space-y-2 overflow-y-auto py-3 sm:py-4">
-                    <div v-for="(d, i) in multiDateDialog.dates" :key="i" class="flex items-center gap-2">
-                        <input
-                            type="date"
-                            v-model="multiDateDialog.dates[i]"
-                            class="w-full rounded border border-border bg-background p-1.5 sm:p-2 text-sm sm:text-base text-foreground"
-                        />
-                        <Button
-                            variant="ghost"
-                            size="icon"
-                            class="h-8 w-8 shrink-0 text-destructive"
-                            :disabled="multiDateDialog.dates.length <= 1"
-                            @click="removeMultiDateRow(i)"
-                        >
-                            <Trash2Icon class="h-4 w-4" />
+                <div class="py-3 sm:py-4">
+                    <!-- Navigation des mois -->
+                    <div class="mb-3 flex items-center justify-between">
+                        <Button type="button" variant="ghost" size="icon" class="h-8 w-8" @click="prevMonth">
+                            <ChevronLeftIcon class="h-4 w-4" />
+                        </Button>
+                        <span class="text-sm font-medium capitalize">{{ calendarLabel }}</span>
+                        <Button type="button" variant="ghost" size="icon" class="h-8 w-8" @click="nextMonth">
+                            <ChevronRightIcon class="h-4 w-4" />
                         </Button>
                     </div>
-                    <Button variant="outline" size="sm" class="w-full" @click="addMultiDateRow">
-                        <PlusIcon class="mr-2 h-4 w-4" /> Ajouter une date
-                    </Button>
+
+                    <!-- Jours de la semaine -->
+                    <div class="mb-1 grid grid-cols-7 gap-1 text-center text-xs text-muted-foreground">
+                        <span v-for="wd in weekdays" :key="wd">{{ wd }}</span>
+                    </div>
+
+                    <!-- Grille des jours -->
+                    <div class="grid grid-cols-7 gap-1">
+                        <template v-for="(cell, i) in calendarCells" :key="i">
+                            <div v-if="!cell" />
+                            <button
+                                v-else
+                                type="button"
+                                :class="[
+                                    'flex h-9 items-center justify-center rounded text-sm transition-colors',
+                                    isDateSelected(cell.iso) ? 'bg-primary font-semibold text-primary-foreground' : 'text-foreground hover:bg-muted',
+                                ]"
+                                @click="toggleDate(cell.iso)"
+                            >
+                                {{ cell.day }}
+                            </button>
+                        </template>
+                    </div>
+
+                    <p class="mt-3 text-xs text-muted-foreground">{{ multiDateDialog.dates.length }} date(s) sélectionnée(s)</p>
                 </div>
                 <DialogFooter class="flex-col xs:flex-row gap-2">
                     <Button variant="outline" @click="multiDateDialog.isOpen = false" class="w-full xs:w-auto">Annuler</Button>
@@ -228,7 +244,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { Head, useForm } from '@inertiajs/vue3';
-import { CalendarPlusIcon, CopyIcon, Loader2Icon, PlusIcon, Trash2Icon } from 'lucide-vue-next';
+import { CalendarPlusIcon, ChevronLeftIcon, ChevronRightIcon, CopyIcon, Loader2Icon, Trash2Icon } from 'lucide-vue-next';
 import { computed, onMounted, ref, watch } from 'vue';
 
 import CostPicker from '@/components/expense/CostPicker.vue';
@@ -399,24 +415,62 @@ const multiDateDialog = ref({
     dates: [],
 });
 
+// Calendrier de sélection multi-dates
+const weekdays = ['Lu', 'Ma', 'Me', 'Je', 'Ve', 'Sa', 'Di'];
+const monthNames = ['janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre'];
+const calendarMonth = ref({ year: 2026, month: 0 });
+
+const pad = (n) => String(n).padStart(2, '0');
+const toIso = (year, month, day) => `${year}-${pad(month + 1)}-${pad(day)}`;
+
+const calendarLabel = computed(() => `${monthNames[calendarMonth.value.month]} ${calendarMonth.value.year}`);
+
+const calendarCells = computed(() => {
+    const { year, month } = calendarMonth.value;
+    const offset = (new Date(year, month, 1).getDay() + 6) % 7; // lundi = 0
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const cells = [];
+    for (let i = 0; i < offset; i++) {
+        cells.push(null);
+    }
+    for (let d = 1; d <= daysInMonth; d++) {
+        cells.push({ day: d, iso: toIso(year, month, d) });
+    }
+    return cells;
+});
+
+const isDateSelected = (iso) => multiDateDialog.value.dates.includes(iso);
+
+const toggleDate = (iso) => {
+    const dates = multiDateDialog.value.dates;
+    const idx = dates.indexOf(iso);
+    if (idx === -1) {
+        dates.push(iso);
+    } else {
+        dates.splice(idx, 1);
+    }
+};
+
+const prevMonth = () => {
+    const { year, month } = calendarMonth.value;
+    calendarMonth.value = month === 0 ? { year: year - 1, month: 11 } : { year, month: month - 1 };
+};
+
+const nextMonth = () => {
+    const { year, month } = calendarMonth.value;
+    calendarMonth.value = month === 11 ? { year: year + 1, month: 0 } : { year, month: month + 1 };
+};
+
 const openMultiDateDialog = (index) => {
     const cost = selectedCosts.value[index];
-    const today = new Date().toISOString().split('T')[0];
+    const now = new Date();
+    calendarMonth.value = { year: now.getFullYear(), month: now.getMonth() };
     multiDateDialog.value = {
         isOpen: true,
         costIndex: index,
         costName: cost.name,
-        dates: [today],
+        dates: [],
     };
-};
-
-const addMultiDateRow = () => {
-    const today = new Date().toISOString().split('T')[0];
-    multiDateDialog.value.dates.push(today);
-};
-
-const removeMultiDateRow = (i) => {
-    multiDateDialog.value.dates.splice(i, 1);
 };
 
 const buildCostDataForDate = (cost, sourceData, date) => {

--- a/resources/js/pages/expenseSheet/Edit.vue
+++ b/resources/js/pages/expenseSheet/Edit.vue
@@ -54,15 +54,25 @@
                     :key="index"
                     class="relative space-y-3 sm:space-y-4 rounded border border-border bg-card p-3 sm:p-4 text-card-foreground"
                 >
-                    <!-- Bouton supprimer -->
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        class="absolute top-2 right-2 h-8 w-8 sm:h-10 sm:w-10 text-destructive"
-                        @click="removeCost(index)"
-                    >
-                        <Trash2Icon class="w-4 h-4 sm:w-5 sm:h-5" />
-                    </Button>
+                    <!-- Boutons d'action -->
+                    <div class="absolute right-2 top-2 flex gap-1 sm:gap-2">
+                        <Button
+                            v-if="canUseMultiDate(cost)"
+                            variant="ghost"
+                            size="icon"
+                            class="h-8 w-8 sm:h-10 sm:w-10 text-primary"
+                            title="Répartir ce coût sur plusieurs dates"
+                            @click="openMultiDateDialog(index)"
+                        >
+                            <CalendarPlusIcon class="h-4 w-4 sm:h-5 sm:w-5" />
+                        </Button>
+                        <Button variant="ghost" size="icon" class="h-8 w-8 sm:h-10 sm:w-10 text-primary" @click="openDuplicateDialog(index)">
+                            <CopyIcon class="h-4 w-4 sm:h-5 sm:w-5" />
+                        </Button>
+                        <Button variant="ghost" size="icon" class="h-8 w-8 sm:h-10 sm:w-10 text-destructive" @click="removeCost(index)">
+                            <Trash2Icon class="h-4 w-4 sm:h-5 sm:h-5" />
+                        </Button>
+                    </div>
 
                     <!-- En-tête coût -->
                     <div class="flex flex-col xs:flex-row xs:items-center xs:justify-between gap-2 pr-20 xs:pr-24">
@@ -153,6 +163,77 @@
                 </Button>
             </div>
         </div>
+
+        <!-- Modal de duplication -->
+        <Dialog v-model:open="duplicateDialog.isOpen">
+            <DialogContent class="max-w-[90vw] sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle class="text-base sm:text-lg">Dupliquer le coût</DialogTitle>
+                    <DialogDescription class="text-xs sm:text-sm"> Combien de copies de "{{ duplicateDialog.costName }}" voulez-vous créer ? </DialogDescription>
+                </DialogHeader>
+                <div class="py-3 sm:py-4">
+                    <Label for="duplicate-count" class="text-xs sm:text-sm">Nombre de copies</Label>
+                    <Input id="duplicate-count" type="number" min="1" max="20" v-model.number="duplicateDialog.count" class="mt-2" />
+                </div>
+                <DialogFooter class="flex-col xs:flex-row gap-2">
+                    <Button variant="outline" @click="duplicateDialog.isOpen = false" class="w-full xs:w-auto">Annuler</Button>
+                    <Button @click="confirmDuplicate" class="w-full xs:w-auto">Dupliquer</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+
+        <!-- Modal de répartition sur plusieurs dates -->
+        <Dialog v-model:open="multiDateDialog.isOpen">
+            <DialogContent class="max-w-[90vw] sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle class="text-base sm:text-lg">Répartir sur plusieurs dates</DialogTitle>
+                    <DialogDescription class="text-xs sm:text-sm">
+                        Sélectionnez les dates auxquelles vous avez effectué "{{ multiDateDialog.costName }}". Une copie du coût sera créée pour chaque date.
+                    </DialogDescription>
+                </DialogHeader>
+                <div class="py-3 sm:py-4">
+                    <!-- Navigation des mois -->
+                    <div class="mb-3 flex items-center justify-between">
+                        <Button type="button" variant="ghost" size="icon" class="h-8 w-8" @click="prevMonth">
+                            <ChevronLeftIcon class="h-4 w-4" />
+                        </Button>
+                        <span class="text-sm font-medium capitalize">{{ calendarLabel }}</span>
+                        <Button type="button" variant="ghost" size="icon" class="h-8 w-8" @click="nextMonth">
+                            <ChevronRightIcon class="h-4 w-4" />
+                        </Button>
+                    </div>
+
+                    <!-- Jours de la semaine -->
+                    <div class="mb-1 grid grid-cols-7 gap-1 text-center text-xs text-muted-foreground">
+                        <span v-for="wd in weekdays" :key="wd">{{ wd }}</span>
+                    </div>
+
+                    <!-- Grille des jours -->
+                    <div class="grid grid-cols-7 gap-1">
+                        <template v-for="(cell, i) in calendarCells" :key="i">
+                            <div v-if="!cell" />
+                            <button
+                                v-else
+                                type="button"
+                                :class="[
+                                    'flex h-9 items-center justify-center rounded text-sm transition-colors',
+                                    isDateSelected(cell.iso) ? 'bg-primary font-semibold text-primary-foreground' : 'text-foreground hover:bg-muted',
+                                ]"
+                                @click="toggleDate(cell.iso)"
+                            >
+                                {{ cell.day }}
+                            </button>
+                        </template>
+                    </div>
+
+                    <p class="mt-3 text-xs text-muted-foreground">{{ multiDateDialog.dates.length }} date(s) sélectionnée(s)</p>
+                </div>
+                <DialogFooter class="flex-col xs:flex-row gap-2">
+                    <Button variant="outline" @click="multiDateDialog.isOpen = false" class="w-full xs:w-auto">Annuler</Button>
+                    <Button @click="confirmMultiDate" class="w-full xs:w-auto">Ajouter les coûts</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
     </AppLayout>
 </template>
 
@@ -169,7 +250,16 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
-import { Loader2Icon, Trash2Icon } from "lucide-vue-next";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { CalendarPlusIcon, ChevronLeftIcon, ChevronRightIcon, CopyIcon, Loader2Icon, Trash2Icon } from "lucide-vue-next";
 
 import CostPicker from "@/components/expense/CostPicker.vue";
 import KmCostInput from "@/components/expense/KmCostInput.vue";
@@ -323,6 +413,186 @@ const addToRequest = (cost) => {
 const removeCost = (index) => {
     selectedCosts.value.splice(index, 1);
     costData.value.splice(index, 1);
+};
+
+// Clone une métadonnée de coût pour une copie, sans réutiliser les
+// prérequis/fichiers déjà enregistrés sur la ligne d'origine.
+const cloneCostMeta = (cost) => {
+    const clone = JSON.parse(JSON.stringify(cost));
+    delete clone.requirements_data;
+    return clone;
+};
+
+// Gestion de la duplication
+const duplicateDialog = ref({
+    isOpen: false,
+    costIndex: -1,
+    costName: '',
+    count: 1,
+});
+
+const openDuplicateDialog = (index) => {
+    const cost = selectedCosts.value[index];
+    duplicateDialog.value = {
+        isOpen: true,
+        costIndex: index,
+        costName: cost.name,
+        count: 1,
+    };
+};
+
+const confirmDuplicate = () => {
+    const { costIndex, count } = duplicateDialog.value;
+
+    if (selectedCosts.value.length + count > 30) {
+        alert(`Vous ne pouvez pas ajouter ${count} coûts. Maximum 30 coûts au total.`);
+        return;
+    }
+
+    const originalCost = selectedCosts.value[costIndex];
+    const originalData = costData.value[costIndex];
+
+    for (let i = 0; i < count; i++) {
+        selectedCosts.value.push(cloneCostMeta(originalCost));
+        costData.value.push({
+            date: originalData.date,
+            kmData: JSON.parse(JSON.stringify(originalData.kmData || {})),
+            percentageData: { ...originalData.percentageData },
+            requirements: {},
+            fixedAmount: originalData.fixedAmount,
+        });
+    }
+
+    duplicateDialog.value.isOpen = false;
+};
+
+// Répartition d'un coût sur plusieurs dates
+// Disponible pour les coûts sans annexe (prérequis de type fichier) : km,
+// pourcentage et fixe. Les éventuels prérequis texte sont recopiés sur chaque date.
+const hasAnnexeRequirement = (cost) => (cost.requirements || []).some((r) => r.type === 'file');
+const canUseMultiDate = (cost) => !hasAnnexeRequirement(cost);
+
+const multiDateDialog = ref({
+    isOpen: false,
+    costIndex: -1,
+    costName: '',
+    dates: [],
+});
+
+// Calendrier de sélection multi-dates
+const weekdays = ['Lu', 'Ma', 'Me', 'Je', 'Ve', 'Sa', 'Di'];
+const monthNames = ['janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre'];
+const calendarMonth = ref({ year: 2026, month: 0 });
+
+const pad = (n) => String(n).padStart(2, '0');
+const toIso = (year, month, day) => `${year}-${pad(month + 1)}-${pad(day)}`;
+
+const calendarLabel = computed(() => `${monthNames[calendarMonth.value.month]} ${calendarMonth.value.year}`);
+
+const calendarCells = computed(() => {
+    const { year, month } = calendarMonth.value;
+    const offset = (new Date(year, month, 1).getDay() + 6) % 7; // lundi = 0
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const cells = [];
+    for (let i = 0; i < offset; i++) {
+        cells.push(null);
+    }
+    for (let d = 1; d <= daysInMonth; d++) {
+        cells.push({ day: d, iso: toIso(year, month, d) });
+    }
+    return cells;
+});
+
+const isDateSelected = (iso) => multiDateDialog.value.dates.includes(iso);
+
+const toggleDate = (iso) => {
+    const dates = multiDateDialog.value.dates;
+    const idx = dates.indexOf(iso);
+    if (idx === -1) {
+        dates.push(iso);
+    } else {
+        dates.splice(idx, 1);
+    }
+};
+
+const prevMonth = () => {
+    const { year, month } = calendarMonth.value;
+    calendarMonth.value = month === 0 ? { year: year - 1, month: 11 } : { year, month: month - 1 };
+};
+
+const nextMonth = () => {
+    const { year, month } = calendarMonth.value;
+    calendarMonth.value = month === 11 ? { year: year + 1, month: 0 } : { year, month: month + 1 };
+};
+
+const openMultiDateDialog = (index) => {
+    const cost = selectedCosts.value[index];
+    const now = new Date();
+    calendarMonth.value = { year: now.getFullYear(), month: now.getMonth() };
+    multiDateDialog.value = {
+        isOpen: true,
+        costIndex: index,
+        costName: cost.name,
+        dates: [],
+    };
+};
+
+const buildCostDataForDate = (cost, sourceData, date) => {
+    const rate = getActiveRate(cost, date);
+
+    // Recopie des prérequis texte (les annexes sont exclues via canUseMultiDate)
+    const requirements = {};
+    Object.entries(sourceData.requirements || {}).forEach(([key, value]) => {
+        if (!(value instanceof File)) {
+            requirements[key] = value;
+        }
+    });
+
+    const data = {
+        date,
+        kmData: JSON.parse(JSON.stringify(sourceData.kmData || {})),
+        percentageData: {
+            paidAmount: sourceData.percentageData?.paidAmount ?? null,
+            percentage: rate,
+            reimbursedAmount: 0,
+        },
+        requirements,
+        fixedAmount: rate,
+    };
+
+    if (cost.type === 'percentage') {
+        const paid = data.percentageData.paidAmount;
+        if (paid !== null && typeof paid !== 'undefined' && paid !== '') {
+            data.percentageData.reimbursedAmount = (paid * rate) / 100;
+        }
+    }
+
+    return data;
+};
+
+const confirmMultiDate = () => {
+    const { costIndex, dates } = multiDateDialog.value;
+
+    const validDates = [...new Set(dates.filter((d) => !!d))];
+    if (!validDates.length) {
+        multiDateDialog.value.isOpen = false;
+        return;
+    }
+
+    if (selectedCosts.value.length + validDates.length > 30) {
+        alert(`Vous ne pouvez pas ajouter ${validDates.length} coûts. Maximum 30 coûts au total.`);
+        return;
+    }
+
+    const originalCost = selectedCosts.value[costIndex];
+    const originalData = costData.value[costIndex];
+
+    validDates.forEach((date) => {
+        selectedCosts.value.push(cloneCostMeta(originalCost));
+        costData.value.push(buildCostDataForDate(originalCost, originalData, date));
+    });
+
+    multiDateDialog.value.isOpen = false;
 };
 
 const updateRate = (index, cost) => {

--- a/tests/Feature/ExpenseSheetMultiDateTest.php
+++ b/tests/Feature/ExpenseSheetMultiDateTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Department;
+use App\Models\ExpenseSheet;
 use App\Models\ExpenseSheetCost;
 use App\Models\Form;
 use App\Models\FormCost;
@@ -69,6 +70,56 @@ class ExpenseSheetMultiDateTest extends TestCase
 
         foreach ($dates as $date) {
             $this->assertDatabaseHas('expense_sheet_costs', [
+                'form_cost_id' => $context['formCost']->id,
+                'date' => $date,
+                'total' => 25,
+            ]);
+        }
+    }
+
+    public function test_multi_date_update_replaces_with_one_cost_per_date(): void
+    {
+        $context = $this->bootstrap();
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $expenseSheet = ExpenseSheet::create([
+            'user_id' => $context['user']->id,
+            'created_by' => $context['user']->id,
+            'status' => 'En attente',
+            'total' => 25,
+            'form_id' => $context['form']->id,
+            'department_id' => $context['department']->id,
+            'is_draft' => false,
+        ]);
+        $expenseSheet->costs()->create([
+            'form_cost_id' => $context['formCost']->id,
+            'type' => 'fixed',
+            'total' => 25,
+            'date' => '2026-04-01',
+            'requirements' => json_encode([]),
+        ]);
+
+        $dates = ['2026-06-01', '2026-06-08', '2026-06-15'];
+
+        $payload = [
+            '_method' => 'PUT',
+            'department_id' => $context['department']->id,
+            'costs' => array_map(fn (string $date): array => [
+                'cost_id' => $context['formCost']->id,
+                'data' => ['amount' => 25],
+                'date' => $date,
+            ], $dates),
+        ];
+
+        $response = $this->actingAs($admin)
+            ->put("/expense-sheet/{$expenseSheet->id}", $payload);
+
+        $response->assertSessionHasNoErrors();
+        $this->assertSame(3, ExpenseSheetCost::count());
+
+        foreach ($dates as $date) {
+            $this->assertDatabaseHas('expense_sheet_costs', [
+                'expense_sheet_id' => $expenseSheet->id,
                 'form_cost_id' => $context['formCost']->id,
                 'date' => $date,
                 'total' => 25,

--- a/tests/Feature/ExpenseSheetMultiDateTest.php
+++ b/tests/Feature/ExpenseSheetMultiDateTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\ExpenseSheetCost;
+use App\Models\Form;
+use App\Models\FormCost;
+use App\Models\FormCostRemboursiementRate;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ExpenseSheetMultiDateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function bootstrap(): array
+    {
+        Notification::fake();
+        Storage::fake('public');
+
+        $department = Department::factory()->create();
+        $user = User::factory()->create(['is_admin' => false]);
+        $department->users()->attach($user->id);
+
+        $form = Form::factory()->create();
+        $formCost = new FormCost;
+        $formCost->name = 'Repas';
+        $formCost->description = 'Indemnité repas sans prérequis';
+        $formCost->type = 'fixed';
+        $formCost->form_id = $form->id;
+        $formCost->save();
+
+        $rate = new FormCostRemboursiementRate;
+        $rate->form_cost_id = $formCost->id;
+        $rate->start_date = '2026-01-01';
+        $rate->end_date = null;
+        $rate->value = 25;
+        $rate->save();
+
+        return compact('department', 'user', 'form', 'formCost');
+    }
+
+    public function test_multi_date_submission_persists_one_cost_per_date(): void
+    {
+        $context = $this->bootstrap();
+
+        $dates = ['2026-05-01', '2026-05-08', '2026-05-15'];
+
+        $payload = [
+            'department_id' => $context['department']->id,
+            'is_draft' => 0,
+            'costs' => array_map(fn (string $date): array => [
+                'cost_id' => $context['formCost']->id,
+                'data' => ['amount' => 25],
+                'date' => $date,
+            ], $dates),
+        ];
+
+        $response = $this->actingAs($context['user'])
+            ->post("/expense-sheet/{$context['form']->id}", $payload);
+
+        $response->assertSessionHasNoErrors();
+        $this->assertDatabaseCount('expense_sheets', 1);
+        $this->assertSame(3, ExpenseSheetCost::count());
+
+        foreach ($dates as $date) {
+            $this->assertDatabaseHas('expense_sheet_costs', [
+                'form_cost_id' => $context['formCost']->id,
+                'date' => $date,
+                'total' => 25,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Résumé

Ajoute la possibilité de **répartir un même coût sur plusieurs dates** via un calendrier, et porte la **duplication de coût** sur la vue d'édition. Disponible sur la création **et** l'édition d'une note de frais.

## Ce qui change

- **Bouton calendrier « Répartir sur plusieurs dates »** à côté du bouton dupliquer :
  - Calendrier mensuel **navigable** (mois précédent/suivant), **sélection multiple** des jours au clic (composant maison, sans nouvelle dépendance).
  - À la confirmation, une copie du coût est créée par date sélectionnée, avec le **taux recalculé pour chaque date**.
  - Disponible pour les coûts **sans annexe** (prérequis de type fichier) : km, pourcentage et fixe. Les prérequis **texte** éventuels sont recopiés sur chaque date.
- **Vue édition (`Edit.vue`)** : ajout du **bouton dupliquer** et du **bouton calendrier** (mêmes comportements que la création).
  - Les copies sont clonées **sans `requirements_data`** pour ne pas réattacher par erreur les fichiers/valeurs déjà enregistrés sur la ligne d'origine.
  - La duplication conserve la date d'origine (champ requis en édition).

## Notes pour la revue

- Le backend (`store` / `update`) gérait déjà un tableau de coûts avec des dates distinctes : la fonctionnalité est **purement frontend** (génération de plusieurs lignes), le contrat backend est inchangé.
- Pour le KM, les données de trajet sont clonées en profondeur (départ/arrivée/étapes).

## Tests

- Nouveau `tests/Feature/ExpenseSheetMultiDateTest.php` couvrant la **création** (`store`) et l'**édition** (`update`) : un envoi multi-dates persiste bien une ligne par date.
- Suite complète au vert : **145 tests, 470 assertions**.