### PR TITLE
Export SRH : colonnes de coûts regroupées par mois

### DIFF
--- a/app/Http/Controllers/ExpenseSheetExportController.php
+++ b/app/Http/Controllers/ExpenseSheetExportController.php
@@ -4,17 +4,19 @@ namespace App\Http\Controllers;
 
 use App\Models\ExpenseSheet;
 use App\Models\ExpenseSheetExport;
+use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
-use Illuminate\Support\Facades\Storage;
 
 class ExpenseSheetExportController extends Controller
 {
-    public function index() {
-$exports = ExpenseSheetExport::orderBy('created_at', 'desc')->get();
+    public function index()
+    {
+        $exports = ExpenseSheetExport::orderBy('created_at', 'desc')->get();
 
         return Inertia::render('expenseSheet/Export/Index', [
             'exports' => $exports,
@@ -24,28 +26,27 @@ $exports = ExpenseSheetExport::orderBy('created_at', 'desc')->get();
     /**
      * Export the expense sheets total to a CSV file.
      */
-
     public function export(Request $request)
     {
         // Vérifie que l'utilisateur à la permission d'exporter
-        if (!auth()->user()->can('export', ExpenseSheet::class)) {
+        if (! auth()->user()->can('export', ExpenseSheet::class)) {
             abort(403);
         }
 
         $validated = $request->validate([
             'start_date' => 'required|date',
-            'end_date'   => 'required|date',
+            'end_date' => 'required|date',
         ]);
 
         $startDate = Carbon::parse($validated['start_date'])->startOfDay();
-        $endDate   = Carbon::parse($validated['end_date'])->endOfDay();
+        $endDate = Carbon::parse($validated['end_date'])->endOfDay();
 
         // Petite validation supplémentaire : début <= fin
         if ($startDate->gt($endDate)) {
             return back()->withErrors(['end_date' => 'La date de fin doit être postérieure à la date de début.']);
         }
 
-        $users = \App\Models\User::whereHas('expenseSheets', function ($q) use ($startDate, $endDate) {
+        $users = User::whereHas('expenseSheets', function ($q) use ($startDate, $endDate) {
             $q->where('approved', true)
                 ->whereBetween('validated_at', [$startDate, $endDate]);
         })
@@ -54,50 +55,80 @@ $exports = ExpenseSheetExport::orderBy('created_at', 'desc')->get();
                     $q->where('approved', true)
                         ->whereBetween('validated_at', [$startDate, $endDate]);
                 },
-                'expenseSheets.expenseSheetCosts.formCost.form'
+                'expenseSheets.expenseSheetCosts.formCost.form',
             ])->get();
 
-        // Préparer entêtes dynamiques : collecter tous les types de coûts uniques
-        $headers = ['Username'];
-        $costTypes = [];
+        // Préparer entêtes dynamiques regroupées par mois (selon la date du coût) :
+        // pour chaque mois, on collecte les types de coûts utilisés par au moins un agent.
+        // $months['Y-m'] = ['label' => 'AVRIL 2026', 'costTypes' => [key => type]]
+        $months = [];
 
         foreach ($users as $user) {
             foreach ($user->expenseSheets as $expenseSheet) {
                 foreach ($expenseSheet->expenseSheetCosts as $cost) {
-                    // Déterminer le préfixe selon le type
+                    if (empty($cost->date)) {
+                        continue;
+                    }
+
+                    $date = Carbon::parse($cost->date);
+                    $monthKey = $date->format('Y-m');
+
+                    if (! isset($months[$monthKey])) {
+                        $months[$monthKey] = [
+                            'label' => mb_strtoupper($date->locale('fr')->translatedFormat('F Y')),
+                            'costTypes' => [],
+                        ];
+                    }
+
                     $typePrefix = strtolower($cost->formCost->type) === 'km' ? 'KM' : 'EURO';
                     $key = $typePrefix.' - '.$cost->formCost->name.' ('.$cost->formCost->form->name.')';
 
-                    // Stocker le type de coût si pas déjà présent
-                    if (!isset($costTypes[$key])) {
-                        $costTypes[$key] = $cost->formCost->type;
+                    if (! isset($months[$monthKey]['costTypes'][$key])) {
+                        $months[$monthKey]['costTypes'][$key] = $cost->formCost->type;
                     }
                 }
             }
         }
 
-        $headers = array_merge($headers, array_keys($costTypes));
+        // Trier les mois chronologiquement
+        ksort($months);
 
-        // Construire les lignes
+        // Construire les entêtes : Username, puis pour chaque mois une colonne titre
+        // (vide dans les lignes) suivie des colonnes de coûts du mois.
+        $headers = ['Username'];
+        foreach ($months as $month) {
+            $headers[] = $month['label'];
+            foreach (array_keys($month['costTypes']) as $key) {
+                $headers[] = $key;
+            }
+        }
+
+        // Construire les lignes : total par utilisateur, par mois et par coût.
         $data = [];
         foreach ($users as $user) {
-            $costSums = array_fill_keys(array_keys($costTypes), 0);
+            // $sums['Y-m'][key] = total
+            $sums = [];
+            foreach ($months as $monthKey => $month) {
+                $sums[$monthKey] = array_fill_keys(array_keys($month['costTypes']), 0);
+            }
 
             foreach ($user->expenseSheets as $expenseSheet) {
                 foreach ($expenseSheet->expenseSheetCosts as $cost) {
-                    // Utiliser la même logique de clé qu'au-dessus
+                    if (empty($cost->date)) {
+                        continue;
+                    }
+
+                    $monthKey = Carbon::parse($cost->date)->format('Y-m');
                     $typePrefix = strtolower($cost->formCost->type) === 'km' ? 'KM' : 'EURO';
                     $key = $typePrefix.' - '.$cost->formCost->name.' ('.$cost->formCost->form->name.')';
 
-                    if (isset($costSums[$key])) {
+                    if (isset($sums[$monthKey][$key])) {
                         // Si c'est un coût de type KM, on ajoute la distance arrondie
                         if (strtolower($cost->formCost->type) === 'km') {
-                            $googleDistance = $cost->google_distance;
-                            $costSums[$key] += round($googleDistance);
+                            $sums[$monthKey][$key] += round($cost->google_distance);
                         } else {
                             // Sinon, on ajoute le montant en euros
-                            $amount = (float) $cost->amount;
-                            $costSums[$key] += $amount;
+                            $sums[$monthKey][$key] += (float) $cost->amount;
                         }
                     }
                 }
@@ -105,25 +136,30 @@ $exports = ExpenseSheetExport::orderBy('created_at', 'desc')->get();
 
             // Vérifier si l'utilisateur a au moins un montant non-nul
             $hasNonZeroAmount = false;
-            foreach ($costSums as $sum) {
-                if ($sum > 0) {
-                    $hasNonZeroAmount = true;
-                    break;
+            foreach ($sums as $monthSums) {
+                foreach ($monthSums as $sum) {
+                    if ($sum > 0) {
+                        $hasNonZeroAmount = true;
+                        break 2;
+                    }
                 }
             }
 
             // N'ajouter la ligne que si l'utilisateur a au moins un montant
             if ($hasNonZeroAmount) {
                 $row = [$user->name];
-                foreach (array_keys($costTypes) as $key) {
-                    $row[] = $costSums[$key];
+                foreach ($months as $monthKey => $month) {
+                    $row[] = ''; // colonne titre du mois, vide dans les lignes
+                    foreach (array_keys($month['costTypes']) as $key) {
+                        $row[] = $sums[$monthKey][$key];
+                    }
                 }
                 $data[] = $row;
             }
         }
 
         // Générer Excel en mémoire (fichier temporaire)
-        $spreadsheet = new Spreadsheet();
+        $spreadsheet = new Spreadsheet;
         $sheet = $spreadsheet->getActiveSheet();
 
         // Entêtes
@@ -163,10 +199,10 @@ $exports = ExpenseSheetExport::orderBy('created_at', 'desc')->get();
 
         // 🆕 1) Créer l'export en "pending" (sans file_path au départ)
         $export = ExpenseSheetExport::create([
-            'start_date'    => $startDate,
-            'end_date'      => $endDate,
-            'status'        => 'completed',
-            'file_path'     => null,
+            'start_date' => $startDate,
+            'end_date' => $endDate,
+            'status' => 'completed',
+            'file_path' => null,
             'created_by_id' => auth()->id(),
         ]);
 

--- a/tests/Feature/ExpenseSheetExportTest.php
+++ b/tests/Feature/ExpenseSheetExportTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\ExpenseSheet;
+use App\Models\Form;
+use App\Models\FormCost;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use Tests\TestCase;
+
+class ExpenseSheetExportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @param  array<int, array{date: string, amount: float}>  $costs
+     */
+    private function makeSheet(User $user, Department $department, Form $form, FormCost $formCost, array $costs): ExpenseSheet
+    {
+        $sheet = ExpenseSheet::create([
+            'user_id' => $user->id,
+            'created_by' => $user->id,
+            'status' => 'Validé',
+            'total' => 0,
+            'form_id' => $form->id,
+            'department_id' => $department->id,
+            'is_draft' => false,
+            'approved' => true,
+            'validated_at' => '2026-06-10 10:00:00',
+        ]);
+
+        foreach ($costs as $cost) {
+            $sheet->costs()->create([
+                'form_cost_id' => $formCost->id,
+                'type' => 'fixed',
+                'amount' => $cost['amount'],
+                'total' => $cost['amount'],
+                'date' => $cost['date'],
+                'requirements' => json_encode([]),
+            ]);
+        }
+
+        return $sheet;
+    }
+
+    /**
+     * @return array<int, array<int, string|float|null>>
+     */
+    private function readExport(): array
+    {
+        $files = Storage::allFiles('exports');
+        $this->assertCount(1, $files);
+
+        $spreadsheet = IOFactory::load(Storage::path($files[0]));
+
+        return $spreadsheet->getActiveSheet()->toArray();
+    }
+
+    public function test_export_groups_cost_columns_by_month_of_cost_date(): void
+    {
+        Storage::fake();
+
+        $admin = User::factory()->create(['is_admin' => true]);
+        $department = Department::factory()->create();
+        $user = User::factory()->create(['is_admin' => false, 'name' => 'Jean Agent']);
+
+        $form = Form::factory()->create();
+        $formCost = FormCost::factory()->create([
+            'name' => 'Repas',
+            'type' => 'fixed',
+            'form_id' => $form->id,
+        ]);
+
+        // Une note validée en juin, mais avec des coûts datés d'avril et de mai.
+        $this->makeSheet($user, $department, $form, $formCost, [
+            ['date' => '2026-04-05', 'amount' => 25],
+            ['date' => '2026-04-12', 'amount' => 15],
+            ['date' => '2026-05-03', 'amount' => 30],
+        ]);
+
+        $response = $this->actingAs($admin)->get(route('expense-sheets.export', [
+            'start_date' => '2026-06-01',
+            'end_date' => '2026-06-30',
+        ]));
+
+        $response->assertSessionHasNoErrors();
+
+        $rows = $this->readExport();
+        $headers = $rows[0];
+
+        // En-têtes : Username, AVRIL 2026 (titre), colonne coût avril, MAI 2026 (titre), colonne coût mai
+        $costColumn = 'EURO - Repas ('.$form->name.')';
+
+        $this->assertSame('Username', $headers[0]);
+        $this->assertSame('AVRIL 2026', $headers[1]);
+        $this->assertSame($costColumn, $headers[2]);
+        $this->assertSame('MAI 2026', $headers[3]);
+        $this->assertSame($costColumn, $headers[4]);
+
+        // Ligne de l'utilisateur : nom, titre mois vide, total avril (40), titre mois vide, total mai (30)
+        $userRow = $rows[1];
+        $this->assertSame('Jean Agent', $userRow[0]);
+        $this->assertNull($userRow[1]);
+        $this->assertEquals(40, $userRow[2]);
+        $this->assertNull($userRow[3]);
+        $this->assertEquals(30, $userRow[4]);
+    }
+
+    public function test_export_only_includes_months_that_have_costs(): void
+    {
+        Storage::fake();
+
+        $admin = User::factory()->create(['is_admin' => true]);
+        $department = Department::factory()->create();
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $form = Form::factory()->create();
+        $formCost = FormCost::factory()->create([
+            'name' => 'Repas',
+            'type' => 'fixed',
+            'form_id' => $form->id,
+        ]);
+
+        $this->makeSheet($user, $department, $form, $formCost, [
+            ['date' => '2026-04-05', 'amount' => 25],
+        ]);
+
+        $this->actingAs($admin)->get(route('expense-sheets.export', [
+            'start_date' => '2026-06-01',
+            'end_date' => '2026-06-30',
+        ]))->assertSessionHasNoErrors();
+
+        $headers = $this->readExport()[0];
+
+        $this->assertContains('AVRIL 2026', $headers);
+        $this->assertNotContains('MAI 2026', $headers);
+        $this->assertNotContains('JUIN 2026', $headers);
+    }
+}


### PR DESCRIPTION
## Quoi

L'export du SRH affiche désormais les colonnes de types de coûts **regroupées par mois**, selon la **date renseignée du coût** (`expense_sheet_costs.date`).

Pour chaque mois ayant au moins un coût :
- une colonne titre (ex. `AVRIL 2026`, vide dans les lignes, sert de séparateur) ;
- puis les colonnes des coûts utilisés par au moins un agent ce mois-là ;
- le total par utilisateur et par coût pour le mois.

Les mois s'enchaînent dans l'ordre chronologique (`AVRIL 2026`, `MAI 2026`, `JUIN 2026`…) et un mois n'apparaît que s'il contient au moins un coût daté.

## Pourquoi

Avec la répartition multi-dates récente, un coût peut s'étaler sur plusieurs mois. Le SRH a besoin d'une vue mensuelle des totaux par agent et par type de coût.

## Notes pour la review

- L'agrégation reste inchangée : KM = `google_distance` arrondie, sinon `amount`. Seules les lignes avec au moins un montant non nul sont incluses.
- Le filtrage des notes de frais reste basé sur `validated_at` dans la période choisie ; c'est le regroupement en colonnes qui se base sur la date du coût.
- Un coût sans date renseignée est ignoré (pas de mois auquel l'attribuer).
- Libellés de mois en français via Carbon.
- 2 tests ajoutés dans `tests/Feature/ExpenseSheetExportTest.php` (regroupement par mois + exclusion des mois sans coût).

> Note : cette branche contient aussi des commits antérieurs non encore mergés dans `main`.