### PR TITLE
Fix #107 : connexion impossible si l'email contient une majuscule

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Auth;
 
 use Illuminate\Auth\Events\Lockout;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
@@ -22,7 +23,7 @@ class LoginRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
@@ -33,9 +34,19 @@ class LoginRequest extends FormRequest
     }
 
     /**
+     * Prepare the data for validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'email' => Str::lower((string) $this->input('email')),
+        ]);
+    }
+
+    /**
      * Attempt to authenticate the request's credentials.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function authenticate(): void
     {
@@ -55,7 +66,7 @@ class LoginRequest extends FormRequest
     /**
      * Ensure the login request is not rate limited.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function ensureIsNotRateLimited(): void
     {

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -30,6 +30,21 @@ class AuthenticationTest extends TestCase
         $response->assertRedirect(route('dashboard', absolute: false));
     }
 
+    public function test_users_can_authenticate_with_email_containing_uppercase()
+    {
+        $user = User::factory()->create([
+            'email' => 'test@exemple.be',
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => 'Test@Exemple.be',
+            'password' => 'password',
+        ]);
+
+        $this->assertAuthenticated();
+        $response->assertRedirect(route('dashboard', absolute: false));
+    }
+
     public function test_users_can_not_authenticate_with_invalid_password()
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Contexte

Corrige l'issue #107 : la connexion échouait avec « identifiants incorrects » dès que l'email était saisi avec une majuscule (ex. `Test@exemple.be`), alors que l'email est stocké en minuscules à l'inscription.

## Correctif

- Ajout de `prepareForValidation()` dans `LoginRequest` pour normaliser l'email en minuscules avant l'authentification, en cohérence avec la normalisation faite à l'inscription.
- Le `throttleKey()` (rate limiting) était déjà en minuscules, il reste inchangé.

## Test

Ajout de `test_users_can_authenticate_with_email_containing_uppercase` dans `AuthenticationTest`. Suite Auth au vert (5 tests).

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)