### PR TITLE
Restreint l'historique des exports aux utilisateurs autorisés (#114)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,5 @@ Lors de code review, effectue tes reviews en français.
 Ne mets jamais de références à des personnes spécifiques dans tes commentaires. Concentre-toi sur le code et les bonnes pratiques de programmation.
 
 N'utilise pas de mention de co-auteur sur des commits.
+
+Toutes les Pull Requests doivent cibler la branche `developpement` (et non `main`).

--- a/app/Http/Controllers/ExpenseSheetExportController.php
+++ b/app/Http/Controllers/ExpenseSheetExportController.php
@@ -9,13 +9,19 @@ use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
+use Inertia\Response;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
 class ExpenseSheetExportController extends Controller
 {
-    public function index()
+    public function index(): Response
     {
+        // Vérifie que l'utilisateur à la permission d'exporter
+        if (! auth()->user()->can('export', ExpenseSheet::class)) {
+            abort(403);
+        }
+
         $exports = ExpenseSheetExport::orderBy('created_at', 'desc')->get();
 
         return Inertia::render('expenseSheet/Export/Index', [

--- a/tests/Feature/ExpenseSheetExportTest.php
+++ b/tests/Feature/ExpenseSheetExportTest.php
@@ -110,6 +110,20 @@ class ExpenseSheetExportTest extends TestCase
         $this->assertEquals(30, $userRow[4]);
     }
 
+    public function test_export_history_is_forbidden_for_user_without_export_permission(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($user)->get(route('export'))->assertForbidden();
+    }
+
+    public function test_export_history_is_accessible_for_user_with_export_permission(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $this->actingAs($admin)->get(route('export'))->assertOk();
+    }
+
     public function test_export_only_includes_months_that_have_costs(): void
     {
         Storage::fake();


### PR DESCRIPTION
## Contexte

Fixe #114 — la page d'historique des exports (`/expense-sheet/export`) était accessible à tout utilisateur authentifié et vérifié, sans le contrôle d'autorisation `export` appliqué à la génération. Elle divulguait les métadonnées et les liens de téléchargement directs des CSV financiers de l'ensemble des agents (broken access control).

## Changements

- `ExpenseSheetExportController::index()` applique désormais la même garde que `export()` : `abort(403)` si l'utilisateur n'a pas la permission `export` sur `ExpenseSheet`. Ajout du type de retour `Inertia\Response`.
- Deux tests Feature : un utilisateur sans permission reçoit `403`, un utilisateur autorisé reçoit `200`.

## Vérification

`php artisan test tests/Feature/ExpenseSheetExportTest.php` → 4 tests / 19 assertions ✅
`vendor/bin/pint --dirty` → pass

## Note

Le durcissement du téléchargement (point 2 de l'issue — route de téléchargement dédiée plutôt que `file_url` public) n'est pas inclus ici. Le disque par défaut est `local` (non exposé publiquement), et cette PR ferme déjà l'accès à la page qui exposait les URLs. Le point 2 peut être traité séparément si souhaité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)