### PR TITLE
Multi-tenant par organisation (fusion Ville/CPAS) + correctifs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+Lors de code review, effectue tes reviews en français.
+
+Ne mets jamais de références à des personnes spécifiques dans tes commentaires. Concentre-toi sur le code et les bonnes pratiques de programmation.
+
+N'utilise pas de mention de co-auteur sur des commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,5 @@ Lors de code review, effectue tes reviews en français.
 Ne mets jamais de références à des personnes spécifiques dans tes commentaires. Concentre-toi sur le code et les bonnes pratiques de programmation.
 
 N'utilise pas de mention de co-auteur sur des commits.
+
+Toutes les Pull Requests doivent cibler la branche `developpement` (et non `main`).

--- a/app/Console/Commands/BackfillOrganization.php
+++ b/app/Console/Commands/BackfillOrganization.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Department;
+use App\Models\ExpenseSheet;
+use App\Models\ExpenseSheetExport;
+use App\Models\Form;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('organizations:backfill {slug}')]
+#[Description('Rattache toutes les données non affectées (et tous les utilisateurs) à une organisation.')]
+class BackfillOrganization extends Command
+{
+    /**
+     * Execute the console command.
+     *
+     * Idempotent : n'affecte que les lignes dont organization_id est null, et
+     * attache chaque utilisateur à l'organisation sans créer de doublon.
+     */
+    public function handle(): int
+    {
+        $slug = (string) $this->argument('slug');
+
+        $organization = Organization::where('slug', $slug)->first();
+
+        if ($organization === null) {
+            $this->error("Aucune organisation avec le slug « {$slug} ».");
+
+            return self::FAILURE;
+        }
+
+        foreach ([Department::class, Form::class, ExpenseSheet::class, ExpenseSheetExport::class] as $model) {
+            $updated = $model::withoutGlobalScopes()
+                ->whereNull('organization_id')
+                ->update(['organization_id' => $organization->getKey()]);
+
+            $this->line(sprintf('%s : %d ligne(s) rattachée(s).', class_basename($model), $updated));
+        }
+
+        $attached = 0;
+        User::query()->select('id')->chunkById(500, function ($users) use ($organization, &$attached): void {
+            foreach ($users as $user) {
+                $user->organizations()->syncWithoutDetaching([$organization->getKey()]);
+                $attached++;
+            }
+        });
+
+        $this->line("Utilisateurs rattachés : {$attached}.");
+        $this->info("Backfill terminé pour « {$organization->name} ».");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ImportSourceOrganization.php
+++ b/app/Console/Commands/ImportSourceOrganization.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Organization;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+#[Signature('organizations:import-source {slug} {--source=import_source} {--force}')]
+#[Description('Importe les données métier d\'une base source (ex. CPAS) dans le socle, rattachées à une organisation, avec remapping des identifiants.')]
+class ImportSourceOrganization extends Command
+{
+    /**
+     * Anciens ID (source) -> nouveaux ID (socle), par table.
+     *
+     * @var array<string, array<int, int>>
+     */
+    private array $maps = [
+        'users' => [],
+        'forms' => [],
+        'form_costs' => [],
+        'departments' => [],
+        'expense_sheets' => [],
+        'expense_sheet_exports' => [],
+    ];
+
+    private int $orgId;
+
+    private string $source;
+
+    /**
+     * @var list<string>
+     */
+    private array $mergedUsers = [];
+
+    /**
+     * @var list<string>
+     */
+    private array $importedSuperAdmins = [];
+
+    public function handle(): int
+    {
+        $slug = (string) $this->argument('slug');
+        $this->source = (string) $this->option('source');
+
+        $organization = Organization::where('slug', $slug)->first();
+
+        if ($organization === null) {
+            $this->error("Aucune organisation avec le slug « {$slug} ». Lancez d'abord le seeder.");
+
+            return self::FAILURE;
+        }
+
+        $this->orgId = (int) $organization->getKey();
+
+        try {
+            DB::connection($this->source)->getPdo();
+        } catch (\Throwable $e) {
+            $this->error("Connexion source « {$this->source} » inaccessible : ".$e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if (! $this->option('force') && $this->organizationAlreadyPopulated()) {
+            $this->error("L'organisation « {$organization->name} » contient déjà des données. Relancez avec --force si l'import précédent a échoué (après restauration du socle).");
+
+            return self::FAILURE;
+        }
+
+        $this->info("Import de « {$this->source} » vers l'organisation « {$organization->name} »…");
+
+        DB::transaction(function (): void {
+            $this->importUsers();
+            $this->importForms();
+            $this->importDepartments();
+            $this->importExpenseSheets();
+            $this->importExports();
+        });
+
+        $this->report();
+
+        return self::SUCCESS;
+    }
+
+    private function organizationAlreadyPopulated(): bool
+    {
+        foreach (['departments', 'forms', 'expense_sheets', 'expense_sheet_exports'] as $table) {
+            if (DB::table($table)->where('organization_id', $this->orgId)->exists()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Fusionne par email : réutilise le compte existant du socle, sinon le crée.
+     */
+    private function importUsers(): void
+    {
+        foreach ($this->sourceRows('users') as $row) {
+            $data = (array) $row;
+            $oldId = (int) $data['id'];
+            $email = strtolower((string) $data['email']);
+
+            $existing = DB::table('users')->whereRaw('lower(email) = ?', [$email])->first();
+
+            if ($existing !== null) {
+                $this->maps['users'][$oldId] = (int) $existing->id;
+                $this->mergedUsers[] = $email;
+            } else {
+                unset($data['id']);
+                $newId = (int) DB::table('users')->insertGetId($data);
+                $this->maps['users'][$oldId] = $newId;
+
+                if (! empty($data['super_admin'])) {
+                    $this->importedSuperAdmins[] = $email;
+                }
+            }
+
+            DB::table('organization_user')->insertOrIgnore([
+                'organization_id' => $this->orgId,
+                'user_id' => $this->maps['users'][$oldId],
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ]);
+        }
+    }
+
+    private function importForms(): void
+    {
+        $this->copyRows('forms', [], 'forms', assignOrg: true);
+        $this->copyRows('form_requirements', ['form_id' => 'forms']);
+        $this->copyRows('form_costs', ['form_id' => 'forms'], 'form_costs');
+        $this->copyRows('form_cost_remboursiement_rates', ['form_cost_id' => 'form_costs']);
+        $this->copyRows('form_cost_requirements', ['form_cost_id' => 'form_costs']);
+    }
+
+    /**
+     * Deux passes pour l'auto-référence parent_id.
+     */
+    private function importDepartments(): void
+    {
+        $parents = [];
+
+        foreach ($this->sourceRows('departments') as $row) {
+            $data = (array) $row;
+            $oldId = (int) $data['id'];
+            $parents[$oldId] = $data['parent_id'] !== null ? (int) $data['parent_id'] : null;
+
+            unset($data['id']);
+            $data['parent_id'] = null;
+            $data['organization_id'] = $this->orgId;
+
+            $this->maps['departments'][$oldId] = (int) DB::table('departments')->insertGetId($data);
+        }
+
+        foreach ($parents as $oldId => $oldParentId) {
+            if ($oldParentId !== null) {
+                DB::table('departments')
+                    ->where('id', $this->maps['departments'][$oldId])
+                    ->update(['parent_id' => $this->mapId('departments', $oldParentId)]);
+            }
+        }
+
+        $this->copyRows('department_user', ['user_id' => 'users', 'department_id' => 'departments']);
+    }
+
+    private function importExpenseSheets(): void
+    {
+        $this->copyRows('expense_sheets', [
+            'form_id' => 'forms',
+            'user_id' => 'users',
+            'validated_by' => 'users',
+            'department_id' => 'departments',
+            'created_by' => 'users',
+        ], 'expense_sheets', assignOrg: true);
+
+        $this->copyRows('expense_sheet_costs', [
+            'expense_sheet_id' => 'expense_sheets',
+            'form_cost_id' => 'form_costs',
+        ]);
+    }
+
+    private function importExports(): void
+    {
+        $this->copyRows('expense_sheet_exports', ['created_by_id' => 'users'], 'expense_sheet_exports', assignOrg: true);
+        $this->copyRows('expense_sheet_export_expense_sheets', [
+            'expense_sheet_export_id' => 'expense_sheet_exports',
+            'expense_sheet_id' => 'expense_sheets',
+        ]);
+    }
+
+    /**
+     * Copie générique d'une table avec remapping des clés étrangères.
+     *
+     * @param  array<string, string>  $foreignKeys  colonne => nom de la map
+     * @param  string|null  $recordMap  map à alimenter (old id => new id) si la table est référencée
+     */
+    private function copyRows(string $table, array $foreignKeys, ?string $recordMap = null, bool $assignOrg = false): void
+    {
+        foreach ($this->sourceRows($table) as $row) {
+            $data = (array) $row;
+            $oldId = isset($data['id']) ? (int) $data['id'] : null;
+            unset($data['id']);
+
+            foreach ($foreignKeys as $column => $mapName) {
+                if (($data[$column] ?? null) !== null) {
+                    $data[$column] = $this->mapId($mapName, (int) $data[$column]);
+                }
+            }
+
+            if ($assignOrg) {
+                $data['organization_id'] = $this->orgId;
+            }
+
+            if ($recordMap !== null && $oldId !== null) {
+                $this->maps[$recordMap][$oldId] = (int) DB::table($table)->insertGetId($data);
+            } else {
+                DB::table($table)->insert($data);
+            }
+        }
+    }
+
+    /**
+     * @return iterable<object>
+     */
+    private function sourceRows(string $table): iterable
+    {
+        return DB::connection($this->source)->table($table)->orderBy('id')->cursor();
+    }
+
+    private function mapId(string $mapName, int $oldId): int
+    {
+        if (! isset($this->maps[$mapName][$oldId])) {
+            throw new \RuntimeException("Référence introuvable : {$mapName} #{$oldId} n'a pas été importé (intégrité source rompue ?).");
+        }
+
+        return $this->maps[$mapName][$oldId];
+    }
+
+    private function report(): void
+    {
+        $this->newLine();
+        $this->info('Import terminé.');
+        $this->table(['Table', 'Importées'], collect([
+            'users' => count($this->maps['users']),
+            'forms' => count($this->maps['forms']),
+            'form_costs' => count($this->maps['form_costs']),
+            'departments' => count($this->maps['departments']),
+            'expense_sheets' => count($this->maps['expense_sheets']),
+            'expense_sheet_exports' => count($this->maps['expense_sheet_exports']),
+        ])->map(fn ($count, $table) => [$table, $count])->values()->all());
+
+        if ($this->mergedUsers !== []) {
+            $this->warn(count($this->mergedUsers).' utilisateur(s) fusionné(s) par email (compte du socle réutilisé) : '.implode(', ', $this->mergedUsers));
+        }
+
+        if ($this->importedSuperAdmins !== []) {
+            $this->warn('⚠ Super-admins importés (pouvoir transverse à toutes les orgs) — à vérifier : '.implode(', ', $this->importedSuperAdmins));
+        }
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -33,6 +33,7 @@ class DashboardController extends Controller
         // Candidats à la validation : je suis head du département de la note OU du parent (N+1)
         $candidateToValidate = ExpenseSheet::query()
             ->withValidationRelations()
+            ->with('costs')
             ->pendingValidationBy($user)
             ->orderBy('created_at', 'desc')
             ->get();

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Models\ExpenseSheet;
 use App\Models\Form;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 
 class DashboardController extends Controller
@@ -12,7 +11,7 @@ class DashboardController extends Controller
     public function index()
     {
         $forms = Form::all();
-        $user  = auth()->user();
+        $user = auth()->user();
 
         // Query de base pour MES notes (filtré par mois en cours)
         $baseQueryMyNotes = ExpenseSheet::with([
@@ -20,7 +19,7 @@ class DashboardController extends Controller
             'costs',
             'department.heads',
             'department.parent.heads',
-            'user'
+            'user',
         ])
             ->whereMonth('created_at', now()->month)
             ->whereYear('created_at', now()->year)
@@ -31,28 +30,12 @@ class DashboardController extends Controller
             ->where('user_id', $user->id)
             ->get();
 
-        // Query de base pour les notes à valider (SANS filtre de mois)
-        $baseQueryToValidate = ExpenseSheet::with([
-            'form',
-            'costs',
-            'department.heads',
-            'department.parent.heads',
-            'user'
-        ])
-            ->orderBy('created_at', 'desc');
-
         // Candidats à la validation : je suis head du département de la note OU du parent (N+1)
-        $candidateToValidate = (clone $baseQueryToValidate)
-            ->where(function ($q) use ($user) {
-                $q->whereHas('department.heads', function ($h) use ($user) {
-                    $h->where('users.id', $user->id);
-                })
-                    ->orWhereHas('department.parent.heads', function ($h) use ($user) {
-                        $h->where('users.id', $user->id);
-                    });
-            })
+        $candidateToValidate = ExpenseSheet::query()
+            ->withValidationRelations()
+            ->pendingValidationBy($user)
+            ->orderBy('created_at', 'desc')
             ->get();
-
 
         $expenseToValidate = $candidateToValidate->filter(function ($sheet) {
             return Gate::allows('shouldAppearInValidationList', $sheet);
@@ -67,6 +50,4 @@ class DashboardController extends Controller
             'isHead' => $isHead,
         ]);
     }
-
-
 }

--- a/app/Http/Controllers/DepartmentController.php
+++ b/app/Http/Controllers/DepartmentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Department;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 
@@ -13,7 +14,7 @@ class DepartmentController extends Controller
      */
     public function index()
     {
-        if (!auth()->user()->can('viewAny', Department::class)) {
+        if (! auth()->user()->can('viewAny', Department::class)) {
             return redirect()->route('dashboard')->with('error', 'Vous n\'avez pas la permission de faire ceci.');
         }
 
@@ -27,14 +28,14 @@ class DepartmentController extends Controller
     /**
      * Show the form for creating a new resource.
      */
-    public
-    function create()
+    public function create()
     {
-        if (!auth()->user()->can('create', Department::class)) {
+        if (! auth()->user()->can('create', Department::class)) {
             return redirect()->route('dashboard')->with('error', 'Vous n\'avez pas la permission de faire ceci.');
         }
+
         return Inertia::render('departments/Create', [
-            'users' => \App\Models\User::all(),
+            'users' => User::inCurrentOrganization()->get(),
             'departments' => Department::all(),
         ]);
     }
@@ -42,10 +43,9 @@ class DepartmentController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public
-    function store(Request $request)
+    public function store(Request $request)
     {
-        if (!auth()->user()->can('create', Department::class)) {
+        if (! auth()->user()->can('create', Department::class)) {
             return redirect()->route('dashboard')->with('error', 'Vous n\'avez pas la permission de faire ceci.');
         }
         $validated = $request->validate([
@@ -74,8 +74,7 @@ class DepartmentController extends Controller
     /**
      * Display the specified resource.
      */
-    public
-    function show(string $id)
+    public function show(string $id)
     {
         //
     }
@@ -83,17 +82,17 @@ class DepartmentController extends Controller
     /**
      * Show the form for editing the specified resource.
      */
-    public
-    function edit(string $id)
+    public function edit(string $id)
     {
-        if (!auth()->user()->can('update', Department::findOrFail($id))) {
+        if (! auth()->user()->can('update', Department::findOrFail($id))) {
             return redirect()->route('dashboard')->with('error', 'Vous n\'avez pas la permission de faire ceci.');
         }
+
         return Inertia::render('departments/Edit', [
             'department' => Department::with(['users' => function ($query) {
                 $query->withPivot('is_head');
             }])->find($id),
-            'users' => \App\Models\User::all(),
+            'users' => User::inCurrentOrganization()->get(),
             'departments' => Department::all(),
         ]);
     }
@@ -101,10 +100,9 @@ class DepartmentController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public
-    function update(Request $request, string $id)
+    public function update(Request $request, string $id)
     {
-        if (!auth()->user()->can('update', Department::findOrFail($id))) {
+        if (! auth()->user()->can('update', Department::findOrFail($id))) {
             return redirect()->route('dashboard')->with('error', 'Vous n\'avez pas la permission de faire ceci.');
         }
         $validated = $request->validate([
@@ -135,10 +133,9 @@ class DepartmentController extends Controller
     /**
      * Remove the specified resource from storage.
      */
-    public
-    function destroy(string $id)
+    public function destroy(string $id)
     {
-        if (!auth()->user()->can('delete', Department::findOrFail($id))) {
+        if (! auth()->user()->can('delete', Department::findOrFail($id))) {
             return redirect()->route('dashboard')->with('error', 'Vous n\'avez pas la permission de faire ceci.');
         }
         Department::destroy($id);

--- a/app/Http/Controllers/ExpenseSheetController.php
+++ b/app/Http/Controllers/ExpenseSheetController.php
@@ -828,7 +828,7 @@ class ExpenseSheetController extends Controller
 
         return Pdf::loadView('expenseSheet.pdf', [
             'expenseSheet' => $expenseSheet,
-            'organizationName' => config('app.organization_name'),
+            'organizationName' => currentOrganization()?->organization_name ?? config('app.organization_name'),
         ])->setPaper('a4', 'landscape')
             ->stream('note_de_frais_'.$id.'.pdf'); // inline
     }

--- a/app/Http/Controllers/ExpenseSheetExportController.php
+++ b/app/Http/Controllers/ExpenseSheetExportController.php
@@ -9,13 +9,19 @@ use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
+use Inertia\Response;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
 
 class ExpenseSheetExportController extends Controller
 {
-    public function index()
+    public function index(): Response
     {
+        // Vérifie que l'utilisateur à la permission d'exporter
+        if (! auth()->user()->can('export', ExpenseSheet::class)) {
+            abort(403);
+        }
+
         $exports = ExpenseSheetExport::orderBy('created_at', 'desc')->get();
 
         return Inertia::render('expenseSheet/Export/Index', [

--- a/app/Http/Controllers/ExpenseSheetExportController.php
+++ b/app/Http/Controllers/ExpenseSheetExportController.php
@@ -52,10 +52,11 @@ class ExpenseSheetExportController extends Controller
             return back()->withErrors(['end_date' => 'La date de fin doit être postérieure à la date de début.']);
         }
 
-        $users = User::whereHas('expenseSheets', function ($q) use ($startDate, $endDate) {
-            $q->where('approved', true)
-                ->whereBetween('validated_at', [$startDate, $endDate]);
-        })
+        $users = User::inCurrentOrganization()
+            ->whereHas('expenseSheets', function ($q) use ($startDate, $endDate) {
+                $q->where('approved', true)
+                    ->whereBetween('validated_at', [$startDate, $endDate]);
+            })
             ->with([
                 'expenseSheets' => function ($q) use ($startDate, $endDate) {
                     $q->where('approved', true)

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -25,6 +25,7 @@ class UserController extends Controller
             return redirect()->route('dashboard')->with('error', 'Vous n\'avez pas la permission de faire ceci.');
         }
         $users = User::query()
+            ->inCurrentOrganization()
             ->when(request('search'), function ($query, $search) {
                 $query->where(function ($q) use ($search) {
                     $q->where('name', 'like', "%{$search}%")
@@ -78,6 +79,10 @@ class UserController extends Controller
             'password' => Str::random(40),
             'is_admin' => $validated['is_admin'] ?? false,
         ]);
+
+        if (($organization = currentOrganization()) !== null) {
+            $user->organizations()->syncWithoutDetaching([$organization->getKey()]);
+        }
 
         $attach = collect($validated['departments'] ?? [])
             ->mapWithKeys(fn (array $dept): array => [$dept['id'] => ['is_head' => $dept['is_head'] ?? false]]);

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Department;
+use App\Models\Form;
+use App\Models\User;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
@@ -39,17 +42,24 @@ class HandleInertiaRequests extends Middleware
     {
         [$message, $author] = str(Inspiring::quotes()->random())->explode('-');
 
+        $organization = currentOrganization();
+
         return [
             ...parent::share($request),
             'name' => config('app.name'),
+            'organization' => $organization === null ? null : [
+                'name' => $organization->name,
+                'slug' => $organization->slug,
+                'organizationName' => $organization->organization_name,
+            ],
             'quote' => ['message' => trim($message), 'author' => trim($author)],
             'auth' => [
                 'user' => $request->user(),
                 'can' => [
-                    'departments' => $request->user()?->can('viewAny', \App\Models\Department::class),
-                    'users' => $request->user()?->can('viewAny', \App\Models\User::class),
-                    'forms' => $request->user()?->can('viewAny', \App\Models\Form::class),
-                ]
+                    'departments' => $request->user()?->can('viewAny', Department::class),
+                    'users' => $request->user()?->can('viewAny', User::class),
+                    'forms' => $request->user()?->can('viewAny', Form::class),
+                ],
             ],
             'ziggy' => [
                 ...(new Ziggy)->toArray(),

--- a/app/Http/Middleware/ResolveOrganization.php
+++ b/app/Http/Middleware/ResolveOrganization.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Organization;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class ResolveOrganization
+{
+    /**
+     * Resolve the current organization from the request subdomain, bind it for
+     * the request lifecycle, and ensure the authenticated user belongs to it.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $slug = $this->resolveSlug($request);
+
+        if ($slug === null) {
+            return $next($request);
+        }
+
+        $organization = Organization::where('slug', $slug)->first();
+
+        if ($organization === null) {
+            abort(404);
+        }
+
+        setCurrentOrganization($organization);
+
+        $user = $request->user();
+
+        if ($user !== null && ! $user->super_admin && ! $user->belongsToOrganization($organization)) {
+            abort(403, "Vous n'avez pas accès à cette organisation.");
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Extract the organization slug from the host subdomain, if present.
+     *
+     * `ville.snapfrais.be` (app host `snapfrais.be`) resolves to `ville`.
+     * The bare application host resolves to `null` (no organization context).
+     */
+    private function resolveSlug(Request $request): ?string
+    {
+        $appHost = parse_url((string) config('app.url'), PHP_URL_HOST) ?: 'localhost';
+        $host = $request->getHost();
+
+        if ($host === $appHost || ! Str::endsWith($host, '.'.$appHost)) {
+            return null;
+        }
+
+        $slug = Str::before($host, '.'.$appHost);
+
+        return $slug === '' ? null : $slug;
+    }
+}

--- a/app/Http/Middleware/ResolveOrganization.php
+++ b/app/Http/Middleware/ResolveOrganization.php
@@ -16,16 +16,10 @@ class ResolveOrganization
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $slug = $this->resolveSlug($request);
-
-        if ($slug === null) {
-            return $next($request);
-        }
-
-        $organization = Organization::where('slug', $slug)->first();
+        $organization = $this->resolveOrganization($request);
 
         if ($organization === null) {
-            abort(404);
+            return $next($request);
         }
 
         setCurrentOrganization($organization);
@@ -37,6 +31,39 @@ class ResolveOrganization
         }
 
         return $next($request);
+    }
+
+    /**
+     * Resolve the organization for the request.
+     *
+     * Priority to an exact match on the organization's own `domain`, then a
+     * fallback to the `{slug}.{APP_URL host}` subdomain convention. A subdomain
+     * that matches no organization aborts with 404; the bare application host
+     * (no subdomain, no matching domain) resolves to null (no tenant context).
+     */
+    private function resolveOrganization(Request $request): ?Organization
+    {
+        $host = $request->getHost();
+
+        $organization = Organization::where('domain', $host)->first();
+
+        if ($organization !== null) {
+            return $organization;
+        }
+
+        $slug = $this->resolveSlug($request);
+
+        if ($slug === null) {
+            return null;
+        }
+
+        $organization = Organization::where('slug', $slug)->first();
+
+        if ($organization === null) {
+            abort(404);
+        }
+
+        return $organization;
     }
 
     /**

--- a/app/Jobs/RemindApprovalExpenseSheet.php
+++ b/app/Jobs/RemindApprovalExpenseSheet.php
@@ -2,12 +2,15 @@
 
 namespace App\Jobs;
 
+use App\Models\ExpenseSheet;
+use App\Models\User;
 use App\Notifications\RemindApprovalExpenseSheetNotification as Reminder;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 
 class RemindApprovalExpenseSheet implements ShouldQueue
@@ -24,7 +27,7 @@ class RemindApprovalExpenseSheet implements ShouldQueue
         Log::info('RemindApprovalExpenseSheet job started.');
 
         // Récupérer tous les validateurs potentiels (users qui sont heads d'au moins un département)
-        $potentialValidators = \App\Models\User::whereHas('departments', function ($query) {
+        $potentialValidators = User::whereHas('departments', function ($query) {
             $query->where('is_head', true);
         })->get();
 
@@ -33,25 +36,14 @@ class RemindApprovalExpenseSheet implements ShouldQueue
         // Pour chaque validateur, compter combien de notes il peut valider
         foreach ($potentialValidators as $validator) {
             // Récupérer les notes candidates pour ce validateur (même logique que DashboardController)
-            $candidateSheets = \App\Models\ExpenseSheet::with([
-                'form',
-                'department.heads',
-                'department.parent.heads',
-                'user',
-            ])
-                ->where(function ($q) use ($validator) {
-                    $q->whereHas('department.heads', function ($h) use ($validator) {
-                        $h->where('users.id', $validator->id);
-                    })
-                        ->orWhereHas('department.parent.heads', function ($h) use ($validator) {
-                            $h->where('users.id', $validator->id);
-                        });
-                })
+            $candidateSheets = ExpenseSheet::query()
+                ->withValidationRelations()
+                ->pendingValidationBy($validator)
                 ->get();
 
             // Filtrer avec la même logique que le dashboard (Policy shouldAppearInValidationList)
             $sheetsToValidate = $candidateSheets->filter(function ($sheet) use ($validator) {
-                return \Illuminate\Support\Facades\Gate::forUser($validator)->allows('shouldAppearInValidationList', $sheet);
+                return Gate::forUser($validator)->allows('shouldAppearInValidationList', $sheet);
             });
 
             $count = $sheetsToValidate->count();

--- a/app/Models/Concerns/BelongsToOrganization.php
+++ b/app/Models/Concerns/BelongsToOrganization.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use App\Models\Organization;
+use App\Models\Scopes\OrganizationScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+trait BelongsToOrganization
+{
+    /**
+     * Boot the trait: apply the organization scope and auto-fill organization_id.
+     */
+    public static function bootBelongsToOrganization(): void
+    {
+        static::addGlobalScope(new OrganizationScope);
+
+        static::creating(function (Model $model): void {
+            if (empty($model->organization_id) && ($organization = currentOrganization()) !== null) {
+                $model->organization_id = $organization->getKey();
+            }
+        });
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+}

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\BelongsToOrganization;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -10,7 +11,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
 
 class Department extends Model
 {
-    use HasFactory, LogsActivity, SoftDeletes;
+    use BelongsToOrganization, HasFactory, LogsActivity, SoftDeletes;
 
     protected $fillable = ['name', 'parent_id'];
 

--- a/app/Models/ExpenseSheet.php
+++ b/app/Models/ExpenseSheet.php
@@ -82,12 +82,15 @@ class ExpenseSheet extends Model
 
     /**
      * Eager loading commun aux listes de validation (dashboard et rappel).
+     *
+     * Volontairement sans `costs` : le job de rappel ne fait que compter les
+     * notes et évaluer la policy. Le dashboard, qui affiche le détail, ajoute
+     * `costs` de son côté.
      */
     public function scopeWithValidationRelations(Builder $query): Builder
     {
         return $query->with([
             'form',
-            'costs',
             'department.heads',
             'department.parent.heads',
             'user',

--- a/app/Models/ExpenseSheet.php
+++ b/app/Models/ExpenseSheet.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\BelongsToOrganization;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -12,7 +13,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
 
 class ExpenseSheet extends Model
 {
-    use HasFactory, LogsActivity, SoftDeletes;
+    use BelongsToOrganization, HasFactory, LogsActivity, SoftDeletes;
 
     protected $fillable = [
         'user_id',

--- a/app/Models/ExpenseSheet.php
+++ b/app/Models/ExpenseSheet.php
@@ -81,6 +81,39 @@ class ExpenseSheet extends Model
     }
 
     /**
+     * Eager loading commun aux listes de validation (dashboard et rappel).
+     */
+    public function scopeWithValidationRelations(Builder $query): Builder
+    {
+        return $query->with([
+            'form',
+            'costs',
+            'department.heads',
+            'department.parent.heads',
+            'user',
+        ]);
+    }
+
+    /**
+     * Scope des notes candidates à la validation par un responsable donné.
+     *
+     * Sélectionne les notes dont le validateur est responsable du département
+     * de la note OU du département parent (N+1). Le filtrage fin
+     * (shouldAppearInValidationList) reste appliqué en PHP car il dépend de la policy.
+     */
+    public function scopePendingValidationBy(Builder $query, User $validator): Builder
+    {
+        return $query->where(function ($q) use ($validator) {
+            $q->whereHas('department.heads', function ($h) use ($validator) {
+                $h->where('users.id', $validator->id);
+            })
+                ->orWhereHas('department.parent.heads', function ($h) use ($validator) {
+                    $h->where('users.id', $validator->id);
+                });
+        });
+    }
+
+    /**
      * Scope pour filtrer les notes de frais visibles par l'utilisateur.
      *
      * Un responsable peut voir :

--- a/app/Models/ExpenseSheetExport.php
+++ b/app/Models/ExpenseSheetExport.php
@@ -3,10 +3,14 @@
 namespace App\Models;
 
 use App\Casts\DateCast;
+use App\Models\Concerns\BelongsToOrganization;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ExpenseSheetExport extends Model
 {
+    use BelongsToOrganization;
+
     protected $fillable = [
         'start_date',
         'end_date',
@@ -17,7 +21,7 @@ class ExpenseSheetExport extends Model
 
     protected $casts = [
         'start_date' => DateCast::class,
-        'end_date'   => DateCast::class,
+        'end_date' => DateCast::class,
     ];
 
     protected $appends = ['file_url', 'records_count', 'created_by_name'];
@@ -31,16 +35,17 @@ class ExpenseSheetExport extends Model
     {
         // ⚠️ on précise le nom de la table pivot car il n’est pas le nom par défaut
         return $this->belongsToMany(
-            \App\Models\ExpenseSheet::class,
+            ExpenseSheet::class,
             'expense_sheet_export_expense_sheets' // pivot
         )->withTimestamps();
     }
+
     protected function getRecordsCountAttribute(): int
     {
         return $this->expenseSheets()->count();
     }
 
-    public function createdBy(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    public function createdBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'created_by_id');
     }

--- a/app/Models/Form.php
+++ b/app/Models/Form.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\BelongsToOrganization;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -10,7 +11,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
 
 class Form extends Model
 {
-    use HasFactory, LogsActivity, SoftDeletes;
+    use BelongsToOrganization, HasFactory, LogsActivity, SoftDeletes;
 
     protected $fillable = ['name', 'description', 'organization_id'];
 

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\OrganizationFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+class Organization extends Model
+{
+    /** @use HasFactory<OrganizationFactory> */
+    use HasFactory, LogsActivity;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'slug',
+        'organization_name',
+    ];
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class);
+    }
+
+    public function departments(): HasMany
+    {
+        return $this->hasMany(Department::class);
+    }
+
+    public function forms(): HasMany
+    {
+        return $this->hasMany(Form::class);
+    }
+
+    public function expenseSheets(): HasMany
+    {
+        return $this->hasMany(ExpenseSheet::class);
+    }
+
+    /**
+     * Configure activity logging options.
+     */
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['name', 'slug', 'organization_name'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs()
+            ->useLogName('organization')
+            ->setDescriptionForEvent(fn (string $eventName) => match ($eventName) {
+                'created' => 'Organisation créée',
+                'updated' => 'Organisation modifiée',
+                'deleted' => 'Organisation supprimée',
+                default => "Organisation {$eventName}",
+            });
+    }
+}

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -21,6 +21,7 @@ class Organization extends Model
     protected $fillable = [
         'name',
         'slug',
+        'domain',
         'organization_name',
     ];
 
@@ -50,7 +51,7 @@ class Organization extends Model
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
-            ->logOnly(['name', 'slug', 'organization_name'])
+            ->logOnly(['name', 'slug', 'domain', 'organization_name'])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs()
             ->useLogName('organization')

--- a/app/Models/Scopes/OrganizationScope.php
+++ b/app/Models/Scopes/OrganizationScope.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class OrganizationScope implements Scope
+{
+    /**
+     * Constrain the query to the organization resolved for the current request.
+     *
+     * When no organization is bound (console, queue, or cross-tenant contexts),
+     * the scope is a no-op so the model behaves as usual.
+     */
+    public function apply(Builder $builder, Model $model): void
+    {
+        $organization = currentOrganization();
+
+        if ($organization !== null) {
+            $builder->where($model->qualifyColumn('organization_id'), $organization->getKey());
+        }
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Notifications\ResetPasswordNotification;
 use Database\Factories\UserFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -94,6 +95,33 @@ class User extends Authenticatable implements HasPasskeysContract
     public function organizations()
     {
         return $this->belongsToMany(Organization::class);
+    }
+
+    /**
+     * Determine whether the user is a member of the given organization.
+     */
+    public function belongsToOrganization(Organization $organization): bool
+    {
+        return $this->organizations()
+            ->whereKey($organization->getKey())
+            ->exists();
+    }
+
+    /**
+     * Restrict a query to members of the organization resolved for the current
+     * request. Outside a tenant context (console, queue) it is a no-op.
+     */
+    public function scopeInCurrentOrganization(Builder $query): Builder
+    {
+        $organization = currentOrganization();
+
+        if ($organization !== null) {
+            $query->whereHas('organizations', function ($q) use ($organization) {
+                $q->whereKey($organization->getKey());
+            });
+        }
+
+        return $query;
     }
 
     public function getIsHeadAttribute(): bool

--- a/app/Notifications/RemindApprovalExpenseSheetNotification.php
+++ b/app/Notifications/RemindApprovalExpenseSheetNotification.php
@@ -6,10 +6,11 @@ use App\Models\User;
 use App\Notifications\Concerns\SendsExpoPushNotifications;
 use App\Notifications\Messages\ExpoPushMessage;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class RemindApprovalExpenseSheetNotification extends Notification
+class RemindApprovalExpenseSheetNotification extends Notification implements ShouldQueue
 {
     use Queueable, SendsExpoPushNotifications;
 

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -3,7 +3,6 @@
 namespace App\Policies;
 
 use App\Models\User;
-use Illuminate\Auth\Access\Response;
 
 class UserPolicy
 {
@@ -12,7 +11,7 @@ class UserPolicy
      */
     public function viewAny(User $user): bool
     {
-        return $user->is_admin == true ? true : false;
+        return $user->is_admin === true;
     }
 
     /**
@@ -20,7 +19,7 @@ class UserPolicy
      */
     public function view(User $user, User $managedUser): bool
     {
-        return $user->is_admin == true && $user->organization_id === $managedUser->organization_id;
+        return $this->canManage($user, $managedUser);
     }
 
     /**
@@ -28,7 +27,7 @@ class UserPolicy
      */
     public function create(User $user): bool
     {
-        return $user->is_admin == true ? true : false;
+        return $user->is_admin === true;
     }
 
     /**
@@ -36,7 +35,7 @@ class UserPolicy
      */
     public function update(User $user, User $managedUser): bool
     {
-        return $user->is_admin == true && $user->organization_id === $managedUser->organization_id;
+        return $this->canManage($user, $managedUser);
     }
 
     /**
@@ -44,7 +43,7 @@ class UserPolicy
      */
     public function delete(User $user, User $managedUser): bool
     {
-        return $user->is_admin == true && $user->organization_id === $managedUser->organization_id;
+        return $this->canManage($user, $managedUser);
     }
 
     /**
@@ -52,7 +51,7 @@ class UserPolicy
      */
     public function restore(User $user, User $managedUser): bool
     {
-        return $user->is_admin == true && $user->organization_id === $managedUser->organization_id;
+        return $this->canManage($user, $managedUser);
     }
 
     /**
@@ -60,6 +59,31 @@ class UserPolicy
      */
     public function forceDelete(User $user, User $managedUser): bool
     {
-        return $user->is_admin == true && $user->organization_id === $managedUser->organization_id;
+        return $this->canManage($user, $managedUser);
+    }
+
+    /**
+     * An admin may manage a user only when both share the organization resolved
+     * for the current request. Platform operators (super_admin) are transverse.
+     */
+    private function canManage(User $user, User $managedUser): bool
+    {
+        if ($user->super_admin === true) {
+            return true;
+        }
+
+        if ($user->is_admin !== true) {
+            return false;
+        }
+
+        $organization = currentOrganization();
+
+        // Hors contexte tenant (accès sans sous-domaine), on conserve le
+        // comportement mono-organisation historique.
+        if ($organization === null) {
+            return true;
+        }
+
+        return $managedUser->belongsToOrganization($organization);
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\Organization;
+
+if (! function_exists('currentOrganization')) {
+    /**
+     * Retrieve the organization resolved for the current request, if any.
+     */
+    function currentOrganization(): ?Organization
+    {
+        return app()->bound('tenant.organization')
+            ? app('tenant.organization')
+            : null;
+    }
+}
+
+if (! function_exists('setCurrentOrganization')) {
+    /**
+     * Bind (or clear) the organization for the current request lifecycle.
+     */
+    function setCurrentOrganization(?Organization $organization): void
+    {
+        if ($organization === null) {
+            app()->forgetInstance('tenant.organization');
+
+            return;
+        }
+
+        app()->instance('tenant.organization', $organization);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use App\Http\Middleware\EnsureTermsAreAccepted;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\ResolveOrganization;
 use App\Http\Middleware\ShareImpersonationData;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -20,6 +21,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->encryptCookies(except: ['appearance']);
 
         $middleware->web(append: [
+            ResolveOrganization::class,
             HandleAppearance::class,
             HandleInertiaRequests::class,
             ShareImpersonationData::class,

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/config/database.php
+++ b/config/database.php
@@ -42,6 +42,24 @@ return [
             'synchronous' => null,
         ],
 
+        /*
+         * Connexion en lecture seule vers une copie de la base source à fusionner
+         * (ex. dump de la prod CPAS), utilisée par `organizations:import-source`.
+         */
+        'import_source' => [
+            'driver' => env('IMPORT_DB_CONNECTION', 'mysql'),
+            'url' => env('IMPORT_DB_URL'),
+            'host' => env('IMPORT_DB_HOST', '127.0.0.1'),
+            'port' => env('IMPORT_DB_PORT', '3306'),
+            'database' => env('IMPORT_DB_DATABASE'),
+            'username' => env('IMPORT_DB_USERNAME'),
+            'password' => env('IMPORT_DB_PASSWORD', ''),
+            'charset' => env('IMPORT_DB_CHARSET', 'utf8mb4'),
+            'collation' => env('IMPORT_DB_COLLATION', 'utf8mb4_unicode_ci'),
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ],
+
         'mysql' => [
             'driver' => 'mysql',
             'url' => env('DB_URL'),

--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Organization;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Organization>
+ */
+class OrganizationFactory extends Factory
+{
+    protected $model = Organization::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->company();
+
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.$this->faker->unique()->numberBetween(1, 100000),
+            'organization_name' => $name,
+        ];
+    }
+}

--- a/database/migrations/2026_07_28_093422_create_organizations_table.php
+++ b/database/migrations/2026_07_28_093422_create_organizations_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('organizations', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('organization_name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('organizations');
+    }
+};

--- a/database/migrations/2026_07_28_093423_create_organization_user_table.php
+++ b/database/migrations/2026_07_28_093423_create_organization_user_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('organization_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organization_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unique(['organization_id', 'user_id']);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('organization_user');
+    }
+};

--- a/database/migrations/2026_07_28_093424_add_organization_id_to_tenant_tables.php
+++ b/database/migrations/2026_07_28_093424_add_organization_id_to_tenant_tables.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The tenant-owned tables that receive an organization_id foreign key.
+     *
+     * @var list<string>
+     */
+    private array $tables = [
+        'departments',
+        'forms',
+        'expense_sheets',
+        'expense_sheet_exports',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->foreignId('organization_id')
+                    ->nullable()
+                    ->after('id')
+                    ->constrained()
+                    ->cascadeOnDelete();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->dropConstrainedForeignId('organization_id');
+            });
+        }
+    }
+};

--- a/database/migrations/2026_07_28_113545_add_domain_to_organizations_table.php
+++ b/database/migrations/2026_07_28_113545_add_domain_to_organizations_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->string('domain')->nullable()->unique()->after('slug');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->dropUnique(['domain']);
+            $table->dropColumn('domain');
+        });
+    }
+};

--- a/database/seeders/OrganizationSeeder.php
+++ b/database/seeders/OrganizationSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Organization;
+use Illuminate\Database\Seeder;
+
+class OrganizationSeeder extends Seeder
+{
+    /**
+     * Crée les organisations Ville et CPAS (idempotent).
+     */
+    public function run(): void
+    {
+        $organizations = [
+            ['slug' => 'ville', 'name' => 'Ville', 'organization_name' => "Ville d'ANDENNE"],
+            ['slug' => 'cpas', 'name' => 'CPAS', 'organization_name' => "CPAS d'ANDENNE"],
+        ];
+
+        foreach ($organizations as $organization) {
+            Organization::updateOrCreate(
+                ['slug' => $organization['slug']],
+                [
+                    'name' => $organization['name'],
+                    'organization_name' => $organization['organization_name'],
+                ],
+            );
+        }
+    }
+}

--- a/tests/Feature/ExpenseSheetExportTest.php
+++ b/tests/Feature/ExpenseSheetExportTest.php
@@ -110,6 +110,20 @@ class ExpenseSheetExportTest extends TestCase
         $this->assertEquals(30, $userRow[4]);
     }
 
+    public function test_export_history_is_forbidden_for_user_without_export_permission(): void
+    {
+        $user = User::factory()->create(['is_admin' => false]);
+
+        $this->actingAs($user)->get(route('export'))->assertForbidden();
+    }
+
+    public function test_export_history_is_accessible_for_user_with_export_permission(): void
+    {
+        $admin = User::factory()->create(['is_admin' => true]);
+
+        $this->actingAs($admin)->get(route('export'))->assertOk();
+    }
+
     public function test_export_only_includes_months_that_have_costs(): void
     {
         Storage::fake();

--- a/tests/Feature/ImportSourceOrganizationTest.php
+++ b/tests/Feature/ImportSourceOrganizationTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Department;
+use App\Models\ExpenseSheet;
+use App\Models\Form;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ImportSourceOrganizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $sourceDb;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sourceDb = tempnam(sys_get_temp_dir(), 'cpas_src_');
+
+        config()->set('database.connections.import_source', [
+            'driver' => 'sqlite',
+            'database' => $this->sourceDb,
+            'prefix' => '',
+            'foreign_key_constraints' => false,
+        ]);
+
+        DB::purge('import_source');
+        $this->createSourceSchema();
+    }
+
+    /**
+     * Minimal source schema (domain tables only), mimicking a copy of the CPAS DB.
+     */
+    private function createSourceSchema(): void
+    {
+        $schema = Schema::connection('import_source');
+
+        $schema->create('users', function (Blueprint $t) {
+            $t->id();
+            $t->string('name');
+            $t->string('email');
+            $t->string('password');
+            $t->boolean('is_admin')->default(false);
+            $t->boolean('super_admin')->default(false);
+            $t->timestamps();
+        });
+        $schema->create('forms', function (Blueprint $t) {
+            $t->id();
+            $t->string('name');
+            $t->text('description')->nullable();
+            $t->timestamps();
+        });
+        $schema->create('form_requirements', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('form_id');
+            $t->string('name')->nullable();
+            $t->timestamps();
+        });
+        $schema->create('form_costs', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('form_id');
+            $t->string('name');
+            $t->text('description')->nullable();
+            $t->string('type')->nullable();
+            $t->timestamps();
+        });
+        $schema->create('form_cost_remboursiement_rates', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('form_cost_id');
+            $t->date('start_date')->nullable();
+            $t->decimal('value', 8, 2)->nullable();
+            $t->timestamps();
+        });
+        $schema->create('form_cost_requirements', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('form_cost_id');
+            $t->string('name')->nullable();
+            $t->timestamps();
+        });
+        $schema->create('departments', function (Blueprint $t) {
+            $t->id();
+            $t->string('name');
+            $t->unsignedBigInteger('parent_id')->nullable();
+            $t->timestamps();
+        });
+        $schema->create('department_user', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('department_id');
+            $t->unsignedBigInteger('user_id');
+            $t->boolean('is_head')->default(false);
+            $t->timestamps();
+        });
+        $schema->create('expense_sheets', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('form_id');
+            $t->unsignedBigInteger('user_id');
+            $t->unsignedBigInteger('department_id')->nullable();
+            $t->unsignedBigInteger('validated_by')->nullable();
+            $t->unsignedBigInteger('created_by')->nullable();
+            $t->string('status')->nullable();
+            $t->decimal('total', 10, 2)->nullable();
+            $t->boolean('is_draft')->default(false);
+            $t->timestamps();
+        });
+        $schema->create('expense_sheet_costs', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('expense_sheet_id');
+            $t->unsignedBigInteger('form_cost_id');
+            $t->string('type')->nullable();
+            $t->decimal('total', 10, 2)->nullable();
+            $t->date('date')->nullable();
+            $t->timestamps();
+        });
+        $schema->create('expense_sheet_exports', function (Blueprint $t) {
+            $t->id();
+            $t->date('start_date')->nullable();
+            $t->date('end_date')->nullable();
+            $t->string('status')->nullable();
+            $t->unsignedBigInteger('created_by_id')->nullable();
+            $t->timestamps();
+        });
+        $schema->create('expense_sheet_export_expense_sheets', function (Blueprint $t) {
+            $t->id();
+            $t->unsignedBigInteger('expense_sheet_export_id');
+            $t->unsignedBigInteger('expense_sheet_id');
+            $t->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        DB::purge('import_source');
+
+        if (isset($this->sourceDb) && file_exists($this->sourceDb)) {
+            @unlink($this->sourceDb);
+        }
+
+        setCurrentOrganization(null);
+
+        parent::tearDown();
+    }
+
+    private function seedSource(): void
+    {
+        $now = Carbon::parse('2026-01-01 10:00:00');
+        $source = DB::connection('import_source');
+
+        $source->table('users')->insert([
+            ['id' => 1, 'name' => 'Agent CPAS', 'email' => 'agent@cpas.be', 'password' => 'x', 'created_at' => $now, 'updated_at' => $now],
+            ['id' => 2, 'name' => 'Admin Partagé', 'email' => 'admin@ville.be', 'password' => 'x', 'created_at' => $now, 'updated_at' => $now],
+        ]);
+
+        $source->table('forms')->insert(['id' => 1, 'name' => 'Frais CPAS', 'description' => 'x', 'created_at' => $now, 'updated_at' => $now]);
+        $source->table('form_costs')->insert(['id' => 1, 'form_id' => 1, 'name' => 'KM', 'description' => 'Indemnité', 'type' => 'km', 'created_at' => $now, 'updated_at' => $now]);
+        $source->table('form_cost_remboursiement_rates')->insert(['id' => 1, 'form_cost_id' => 1, 'start_date' => '2026-01-01', 'value' => 0.42, 'created_at' => $now, 'updated_at' => $now]);
+
+        $source->table('departments')->insert([
+            ['id' => 1, 'name' => 'Direction CPAS', 'parent_id' => null, 'created_at' => $now, 'updated_at' => $now],
+            ['id' => 2, 'name' => 'Service Social', 'parent_id' => 1, 'created_at' => $now, 'updated_at' => $now],
+        ]);
+        $source->table('department_user')->insert(['id' => 1, 'department_id' => 2, 'user_id' => 1, 'is_head' => true, 'created_at' => $now, 'updated_at' => $now]);
+
+        $source->table('expense_sheets')->insert([
+            'id' => 1, 'form_id' => 1, 'user_id' => 2, 'department_id' => 2, 'created_by' => 1,
+            'status' => 'En attente', 'total' => 100, 'is_draft' => false, 'created_at' => $now, 'updated_at' => $now,
+        ]);
+        $source->table('expense_sheet_costs')->insert([
+            'id' => 1, 'expense_sheet_id' => 1, 'form_cost_id' => 1, 'type' => 'km', 'total' => 100, 'date' => '2026-01-02', 'created_at' => $now, 'updated_at' => $now,
+        ]);
+
+        $source->table('expense_sheet_exports')->insert(['id' => 1, 'start_date' => '2026-01-01', 'end_date' => '2026-01-31', 'status' => 'done', 'created_by_id' => 1, 'created_at' => $now, 'updated_at' => $now]);
+        $source->table('expense_sheet_export_expense_sheets')->insert(['id' => 1, 'expense_sheet_export_id' => 1, 'expense_sheet_id' => 1, 'created_at' => $now, 'updated_at' => $now]);
+    }
+
+    public function test_it_imports_source_data_with_remapping_and_email_merge(): void
+    {
+        $ville = Organization::factory()->create(['slug' => 'ville']);
+        $cpas = Organization::factory()->create(['slug' => 'cpas']);
+
+        // Compte existant du socle qui partage l'email d'un agent CPAS.
+        $shared = User::factory()->create(['email' => 'admin@ville.be']);
+        $shared->organizations()->attach($ville);
+
+        $this->seedSource();
+
+        $exitCode = Artisan::call('organizations:import-source', ['slug' => 'cpas', '--source' => 'import_source']);
+        $this->assertSame(0, $exitCode);
+
+        // Pas de doublon : l'agent partagé reste un seul compte, dans les DEUX orgs.
+        $this->assertSame(2, User::count());
+        $this->assertTrue($shared->fresh()->belongsToOrganization($ville));
+        $this->assertTrue($shared->fresh()->belongsToOrganization($cpas));
+
+        $agent = User::where('email', 'agent@cpas.be')->firstOrFail();
+        $this->assertTrue($agent->belongsToOrganization($cpas));
+        $this->assertFalse($agent->belongsToOrganization($ville));
+
+        // Isolation : tout le métier importé est rattaché à l'org CPAS.
+        setCurrentOrganization($cpas);
+        $this->assertSame(1, Form::count());
+        $this->assertSame(2, Department::count());
+        $this->assertSame(1, ExpenseSheet::count());
+
+        // L'auto-référence parent_id est correctement remappée.
+        $child = Department::where('name', 'Service Social')->firstOrFail();
+        $parent = Department::where('name', 'Direction CPAS')->firstOrFail();
+        $this->assertSame($parent->id, $child->parent_id);
+
+        // La note de frais pointe vers le compte fusionné (id du socle) et la bonne org.
+        $sheet = ExpenseSheet::firstOrFail();
+        $this->assertSame($shared->id, $sheet->user_id);
+        $this->assertSame($cpas->id, $sheet->organization_id);
+        $this->assertSame($child->id, $sheet->department_id);
+        $this->assertSame(1, $sheet->costs()->count());
+
+        // Le socle Ville n'a reçu aucune donnée métier.
+        setCurrentOrganization($ville);
+        $this->assertSame(0, Form::count());
+        $this->assertSame(0, ExpenseSheet::count());
+    }
+
+    public function test_it_refuses_to_import_twice_without_force(): void
+    {
+        Organization::factory()->create(['slug' => 'cpas']);
+        $this->seedSource();
+
+        $this->assertSame(0, Artisan::call('organizations:import-source', ['slug' => 'cpas', '--source' => 'import_source']));
+        $this->assertSame(1, Artisan::call('organizations:import-source', ['slug' => 'cpas', '--source' => 'import_source']));
+    }
+
+    public function test_it_fails_for_unknown_slug(): void
+    {
+        $this->assertSame(1, Artisan::call('organizations:import-source', ['slug' => 'inconnu', '--source' => 'import_source']));
+    }
+}

--- a/tests/Feature/OrganizationTenancyTest.php
+++ b/tests/Feature/OrganizationTenancyTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OrganizationTenancyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.url' => 'http://snapfrais.test']);
+    }
+
+    protected function tearDown(): void
+    {
+        setCurrentOrganization(null);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Build a URL on the given organization subdomain.
+     */
+    private function on(string $slug, string $routeName, array $params = []): string
+    {
+        return "http://{$slug}.snapfrais.test".route($routeName, $params, absolute: false);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function memberOf(Organization $organization, array $attributes = []): User
+    {
+        $user = User::factory()->create($attributes);
+        $user->organizations()->attach($organization);
+
+        return $user;
+    }
+
+    public function test_unknown_subdomain_returns_404(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get($this->on('inconnu', 'dashboard'))
+            ->assertNotFound();
+    }
+
+    public function test_member_can_access_their_subdomain(): void
+    {
+        $organization = Organization::factory()->create(['slug' => 'ville']);
+        $user = $this->memberOf($organization);
+
+        $this->actingAs($user)
+            ->get($this->on('ville', 'dashboard'))
+            ->assertOk();
+    }
+
+    public function test_non_member_is_forbidden_on_other_subdomain(): void
+    {
+        $orgA = Organization::factory()->create(['slug' => 'ville']);
+        Organization::factory()->create(['slug' => 'cpas']);
+        $user = $this->memberOf($orgA);
+
+        $this->actingAs($user)
+            ->get($this->on('cpas', 'dashboard'))
+            ->assertForbidden();
+    }
+
+    public function test_super_admin_is_transverse(): void
+    {
+        Organization::factory()->create(['slug' => 'cpas']);
+        $super = User::factory()->create(['super_admin' => true]);
+
+        $this->actingAs($super)
+            ->get($this->on('cpas', 'dashboard'))
+            ->assertOk();
+    }
+
+    public function test_user_index_is_scoped_to_subdomain_organization(): void
+    {
+        $orgA = Organization::factory()->create(['slug' => 'ville']);
+        $orgB = Organization::factory()->create(['slug' => 'cpas']);
+
+        $admin = $this->memberOf($orgA, ['is_admin' => true, 'super_admin' => false]);
+        $this->memberOf($orgA);
+        $this->memberOf($orgB);
+
+        $this->actingAs($admin)
+            ->get($this->on('ville', 'users.index'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('users/Index')
+                ->has('users.data', 2)
+            );
+    }
+
+    public function test_inertia_shares_current_organization_branding(): void
+    {
+        $organization = Organization::factory()->create([
+            'slug' => 'ville',
+            'organization_name' => 'Ville de Test',
+        ]);
+        $user = $this->memberOf($organization);
+
+        $this->actingAs($user)
+            ->get($this->on('ville', 'dashboard'))
+            ->assertInertia(fn ($page) => $page
+                ->where('organization.slug', 'ville')
+                ->where('organization.organizationName', 'Ville de Test')
+            );
+    }
+}

--- a/tests/Feature/OrganizationTenancyTest.php
+++ b/tests/Feature/OrganizationTenancyTest.php
@@ -102,6 +102,20 @@ class OrganizationTenancyTest extends TestCase
             );
     }
 
+    public function test_organization_is_resolved_by_its_own_domain(): void
+    {
+        $organization = Organization::factory()->create([
+            'slug' => 'cpas',
+            'domain' => 'frais.cpas-andenne.be',
+        ]);
+        $user = $this->memberOf($organization);
+
+        $this->actingAs($user)
+            ->get('http://frais.cpas-andenne.be'.route('dashboard', absolute: false))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->where('organization.slug', 'cpas'));
+    }
+
     public function test_inertia_shares_current_organization_branding(): void
     {
         $organization = Organization::factory()->create([

--- a/tests/Feature/RemindApprovalExpenseSheetTest.php
+++ b/tests/Feature/RemindApprovalExpenseSheetTest.php
@@ -8,6 +8,7 @@ use App\Models\ExpenseSheet;
 use App\Models\Form;
 use App\Models\User;
 use App\Notifications\RemindApprovalExpenseSheetNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
@@ -163,7 +164,7 @@ class RemindApprovalExpenseSheetTest extends TestCase
         // pour pouvoir valider lui-même ses propres notes
         Notification::assertSentTo(
             $head,
-            \App\Notifications\RemindApprovalExpenseSheetNotification::class
+            RemindApprovalExpenseSheetNotification::class
         );
     }
 
@@ -196,6 +197,46 @@ class RemindApprovalExpenseSheetTest extends TestCase
         // Pas d'auto-validation hors département racine : aucun rappel ne doit être envoyé
         // (c'est au responsable du parent de valider, et il n'y en a pas ici)
         Notification::assertNothingSent();
+    }
+
+    public function test_only_one_reminder_sent_per_validator(): void
+    {
+        Notification::fake();
+
+        // Créer un département avec un responsable
+        $department = Department::factory()->create();
+        $head = User::factory()->create();
+        $department->heads()->attach($head->id, ['is_head' => true]);
+
+        // Créer un utilisateur membre du département (non responsable)
+        $employee = User::factory()->create();
+        $department->users()->attach($employee->id, ['is_head' => false]);
+
+        // Créer un formulaire
+        $form = Form::factory()->create();
+
+        // Créer plusieurs notes de frais en attente de validation
+        ExpenseSheet::factory()->count(3)->create([
+            'user_id' => $employee->id,
+            'department_id' => $department->id,
+            'form_id' => $form->id,
+            'is_draft' => false,
+            'approved' => null,
+        ]);
+
+        // Exécuter le job
+        RemindApprovalExpenseSheet::dispatch();
+
+        // Un seul rappel doit être envoyé au validateur, quel que soit le nombre de notes
+        Notification::assertSentToTimes($head, RemindApprovalExpenseSheetNotification::class, 1);
+    }
+
+    public function test_reminder_notification_is_queued(): void
+    {
+        $this->assertInstanceOf(
+            ShouldQueue::class,
+            new RemindApprovalExpenseSheetNotification(User::factory()->make(), 1)
+        );
     }
 
     public function test_notification_count_matches_dashboard_filtered_count(): void

--- a/tests/Unit/BelongsToOrganizationTest.php
+++ b/tests/Unit/BelongsToOrganizationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Form;
+use App\Models\Organization;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BelongsToOrganizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        setCurrentOrganization(null);
+
+        parent::tearDown();
+    }
+
+    public function test_auto_fills_organization_id_from_current_context(): void
+    {
+        $organization = Organization::factory()->create();
+        setCurrentOrganization($organization);
+
+        $form = Form::create(['name' => 'Frais', 'description' => 'Test']);
+
+        $this->assertSame($organization->id, $form->organization_id);
+    }
+
+    public function test_global_scope_isolates_queries_by_organization(): void
+    {
+        $orgA = Organization::factory()->create();
+        $orgB = Organization::factory()->create();
+
+        Form::factory()->create(['organization_id' => $orgA->id]);
+        Form::factory()->create(['organization_id' => $orgB->id]);
+
+        setCurrentOrganization($orgA);
+        $this->assertSame(1, Form::count());
+
+        setCurrentOrganization($orgB);
+        $this->assertSame(1, Form::count());
+    }
+
+    public function test_no_context_applies_no_scope(): void
+    {
+        $orgA = Organization::factory()->create();
+        $orgB = Organization::factory()->create();
+
+        Form::factory()->create(['organization_id' => $orgA->id]);
+        Form::factory()->create(['organization_id' => $orgB->id]);
+
+        setCurrentOrganization(null);
+
+        $this->assertSame(2, Form::count());
+    }
+
+    public function test_explicit_organization_id_is_not_overwritten(): void
+    {
+        $orgA = Organization::factory()->create();
+        $orgB = Organization::factory()->create();
+        setCurrentOrganization($orgA);
+
+        $form = Form::create([
+            'name' => 'Frais',
+            'description' => 'Test',
+            'organization_id' => $orgB->id,
+        ]);
+
+        $this->assertSame($orgB->id, $form->organization_id);
+    }
+}

--- a/tests/Unit/ExpenseSheetPendingValidationScopeTest.php
+++ b/tests/Unit/ExpenseSheetPendingValidationScopeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Department;
+use App\Models\ExpenseSheet;
+use App\Models\Form;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ExpenseSheetPendingValidationScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_head_gets_sheets_of_own_and_child_department_not_others(): void
+    {
+        $form = Form::factory()->create();
+
+        // Département parent dont le head est le validateur, et un sous-département
+        $parent = Department::factory()->create();
+        $child = Department::factory()->create(['parent_id' => $parent->id]);
+
+        $head = User::factory()->create();
+        $parent->heads()->attach($head->id, ['is_head' => true]);
+
+        // Département sans lien avec le validateur
+        $other = Department::factory()->create();
+
+        $employeeParent = User::factory()->create();
+        $parent->users()->attach($employeeParent->id, ['is_head' => false]);
+
+        $employeeChild = User::factory()->create();
+        $child->users()->attach($employeeChild->id, ['is_head' => false]);
+
+        $employeeOther = User::factory()->create();
+        $other->users()->attach($employeeOther->id, ['is_head' => false]);
+
+        // Note du département du head → candidate
+        $ownSheet = ExpenseSheet::factory()->create([
+            'user_id' => $employeeParent->id,
+            'department_id' => $parent->id,
+            'form_id' => $form->id,
+        ]);
+
+        // Note du sous-département (parent = département du head, N+1) → candidate
+        $childSheet = ExpenseSheet::factory()->create([
+            'user_id' => $employeeChild->id,
+            'department_id' => $child->id,
+            'form_id' => $form->id,
+        ]);
+
+        // Note d'un département tiers → non candidate
+        ExpenseSheet::factory()->create([
+            'user_id' => $employeeOther->id,
+            'department_id' => $other->id,
+            'form_id' => $form->id,
+        ]);
+
+        $candidateIds = ExpenseSheet::query()
+            ->pendingValidationBy($head)
+            ->pluck('id');
+
+        $this->assertEqualsCanonicalizing(
+            [$ownSheet->id, $childSheet->id],
+            $candidateIds->all(),
+            'Le head doit récupérer les notes de son département et du sous-département, pas celles des autres.'
+        );
+    }
+}


### PR DESCRIPTION
## Résumé

Promotion de `developpement` vers `main`. Le gros de cette livraison est le **multi-tenant par organisation**, qui permet de servir Ville et CPAS depuis **une seule base de données**, plus quelques correctifs déjà revus.

## Multi-tenant par organisation

- **Schéma** : table `organizations`, pivot `organization_user` (many-to-many user↔org), colonne `organization_id` sur `departments`/`forms`/`expense_sheets`/`expense_sheet_exports`, et colonne `domain` (nullable, unique) par organisation.
- **Cloisonnement automatique** : trait `BelongsToOrganization` (global scope + auto-remplissage de `organization_id` à la création) sur les modèles racine ; `User` filtré via `scopeInCurrentOrganization` (many-to-many) ; helpers `currentOrganization()` / `setCurrentOrganization()`.
- **Résolution du tenant** : middleware `ResolveOrganization` — correspondance exacte sur `organizations.domain`, repli sur le sous-domaine `{slug}.{APP_URL}` ; 404 si sous-domaine inconnu, 403 si l'utilisateur n'est pas membre (`super_admin` transverse).
- **Autorisation** : `UserPolicy` corrigée (appartenance à l'org courante, repli mono-organisation hors contexte).
- **Branding par org** exposé via Inertia et le PDF des notes de frais.
- **Outillage de fusion** : `OrganizationSeeder`, commande `organizations:backfill {slug}` (rattache l'existant), et `organizations:import-source {slug}` (import d'une base source avec remapping d'ID, fusion des comptes par email, connexion `import_source`).

## Autres changements inclus

- Restreint l'historique des exports aux utilisateurs autorisés (#114).
- Factorise la requête « notes à valider » dans un scope Eloquent (#115).
- Met `RemindApprovalExpenseSheetNotification` en file d'attente (#116).
- Ajoute `AGENTS.md` (consignes de revue de code).

## Tests

Suite complète verte (**168 tests**), dont les nouveaux : cloisonnement (scope + auto-fill), tenancy par sous-domaine et par domaine, et import de la base source.

## À prévoir au déploiement

- Lancer les migrations (nouvelles tables + colonnes).
- Seeder les organisations puis `organizations:backfill ville` pour rattacher les données existantes.
- **`APP_URL` doit être le domaine nu** (ex. `https://snapfrais.be`), pas un sous-domaine, pour que la résolution fonctionne.
- Fusion des données CPAS : via `organizations:import-source` (voir description commande) — à jouer sur copie + backup.

## Points connus non traités

- Résolution par sous-domaine **non appliquée à l'API mobile** (`routes/api.php`, Sanctum).
- Rattachement d'org **non automatique** pour l'import Excel (`UsersImport`) et l'inscription (`RegisteredUserController`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)