### PR TITLE
Liens des mails selon l'organisation

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -93,7 +93,7 @@ class UserController extends Controller
 
         $token = Password::broker()->createToken($user);
 
-        $user->notify(new UserCreated($token, $validated['email']));
+        $user->notify(new UserCreated($token, $validated['email'], currentOrganization()));
 
         return redirect()->route('users.index')->with('success', 'Utilisateur créé. Un lien de définition du mot de passe lui a été envoyé.');
     }
@@ -205,7 +205,7 @@ class UserController extends Controller
 
         $token = Password::broker()->createToken($user);
 
-        $user->notify(new AdminInitiatedPasswordReset($token, auth()->user()->name));
+        $user->notify(new AdminInitiatedPasswordReset($token, auth()->user()->name, currentOrganization()));
 
         return redirect()->back()->with('success', 'Un lien de réinitialisation a été envoyé à '.$user->email.'.');
     }

--- a/app/Jobs/RemindApprovalExpenseSheet.php
+++ b/app/Jobs/RemindApprovalExpenseSheet.php
@@ -48,9 +48,15 @@ class RemindApprovalExpenseSheet implements ShouldQueue
 
             $count = $sheetsToValidate->count();
 
-            // N'envoyer la notification que si au moins une note à valider
+            // N'envoyer la notification que si au moins une note à valider.
+            // On regroupe par organisation pour que chaque rappel pointe vers
+            // le dashboard de la bonne organisation (lien construit hors requête).
             if ($count > 0) {
-                $validator->notify(new Reminder($validator, $count));
+                $sheetsToValidate
+                    ->groupBy(fn ($sheet) => $sheet->organization_id)
+                    ->each(function ($sheets) use ($validator) {
+                        $validator->notify(new Reminder($validator, $sheets->count(), $sheets->first()->organization));
+                    });
                 Log::info("Notification envoyée à {$validator->name} pour {$count} note(s) de frais.");
             } else {
                 Log::info("Aucune notification envoyée à {$validator->name} : 0 note de frais à valider.");

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -46,6 +46,34 @@ class Organization extends Model
     }
 
     /**
+     * Base URL of the organization: its own `domain` if set, otherwise the
+     * `{slug}.{APP_URL host}` subdomain convention. Used to build absolute
+     * links in queued notifications, which run without a request context.
+     */
+    public function baseUrl(): string
+    {
+        $appUrl = (string) config('app.url');
+        $scheme = parse_url($appUrl, PHP_URL_SCHEME) ?: 'https';
+
+        if (! empty($this->domain)) {
+            return $scheme.'://'.$this->domain;
+        }
+
+        $appHost = parse_url($appUrl, PHP_URL_HOST) ?: 'localhost';
+        $port = parse_url($appUrl, PHP_URL_PORT);
+
+        return $scheme.'://'.$this->slug.'.'.$appHost.($port ? ':'.$port : '');
+    }
+
+    /**
+     * Build an absolute URL on the organization's own host.
+     */
+    public function url(string $path = ''): string
+    {
+        return rtrim($this->baseUrl(), '/').'/'.ltrim($path, '/');
+    }
+
+    /**
      * Configure activity logging options.
      */
     public function getActivitylogOptions(): LogOptions

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -225,7 +225,7 @@ class User extends Authenticatable implements HasPasskeysContract
 
     public function sendPasswordResetNotification($token)
     {
-        $this->notify(new ResetPasswordNotification($token));
+        $this->notify(new ResetPasswordNotification($token, currentOrganization()));
     }
 
     /**

--- a/app/Notifications/AdminInitiatedPasswordReset.php
+++ b/app/Notifications/AdminInitiatedPasswordReset.php
@@ -2,6 +2,8 @@
 
 namespace App\Notifications;
 
+use App\Models\Organization;
+use App\Notifications\Concerns\LinksToOrganization;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -9,11 +11,12 @@ use Illuminate\Notifications\Notification;
 
 class AdminInitiatedPasswordReset extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use LinksToOrganization, Queueable;
 
     public function __construct(
         private string $token,
         private string $adminName,
+        private ?Organization $organization = null,
     ) {}
 
     /**
@@ -26,7 +29,7 @@ class AdminInitiatedPasswordReset extends Notification implements ShouldQueue
 
     public function toMail(object $notifiable): MailMessage
     {
-        $url = url(route('password.reset', [
+        $url = $this->organizationUrl($this->organization, route('password.reset', [
             'token' => $this->token,
             'email' => $notifiable->getEmailForPasswordReset(),
         ], false));

--- a/app/Notifications/ApprovalExpenseSheet.php
+++ b/app/Notifications/ApprovalExpenseSheet.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\ExpenseSheet;
+use App\Notifications\Concerns\LinksToOrganization;
 use App\Notifications\Concerns\SendsExpoPushNotifications;
 use App\Notifications\Messages\ExpoPushMessage;
 use Illuminate\Bus\Queueable;
@@ -12,7 +13,7 @@ use Illuminate\Notifications\Notification;
 
 class ApprovalExpenseSheet extends Notification implements ShouldQueue
 {
-    use Queueable, SendsExpoPushNotifications;
+    use LinksToOrganization, Queueable, SendsExpoPushNotifications;
 
     public ExpenseSheet $expenseSheet;
 
@@ -45,7 +46,7 @@ class ApprovalExpenseSheet extends Notification implements ShouldQueue
             ->subject('Votre note de frais #'.$this->expenseSheet->id.' a été approuvée')
             ->greeting('Bonjour,')
             ->line($this->expenseSheet->validatedBy->name.' a approuvé votre note de frais #'.$this->expenseSheet->id)
-            ->action('Voir la note de frais', url('/expense-sheet/'.$this->expenseSheet->id))
+            ->action('Voir la note de frais', $this->organizationUrl($this->expenseSheet->organization, '/expense-sheet/'.$this->expenseSheet->id))
             ->line('Merci d\'utiliser notre application !')
             ->salutation('Bien cordialement,');
     }

--- a/app/Notifications/Concerns/LinksToOrganization.php
+++ b/app/Notifications/Concerns/LinksToOrganization.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Notifications\Concerns;
+
+use App\Models\Organization;
+
+trait LinksToOrganization
+{
+    /**
+     * Build an absolute link on the organization's own host.
+     *
+     * Notifications are queued and therefore run without a request context,
+     * so `url()` would otherwise fall back to the bare APP_URL host. When the
+     * organization is known we route the link to its own domain/subdomain;
+     * otherwise we degrade gracefully to the application default.
+     */
+    protected function organizationUrl(?Organization $organization, string $path): string
+    {
+        return $organization?->url($path) ?? url($path);
+    }
+}

--- a/app/Notifications/ExpenseSheetToApproval.php
+++ b/app/Notifications/ExpenseSheetToApproval.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\ExpenseSheet;
+use App\Notifications\Concerns\LinksToOrganization;
 use App\Notifications\Concerns\SendsExpoPushNotifications;
 use App\Notifications\Messages\ExpoPushMessage;
 use Illuminate\Bus\Queueable;
@@ -12,7 +13,7 @@ use Illuminate\Notifications\Notification;
 
 class ExpenseSheetToApproval extends Notification implements ShouldQueue
 {
-    use Queueable, SendsExpoPushNotifications;
+    use LinksToOrganization, Queueable, SendsExpoPushNotifications;
 
     public ExpenseSheet $sheet;
 
@@ -31,7 +32,7 @@ class ExpenseSheetToApproval extends Notification implements ShouldQueue
         $channels = ['mail'];
 
         return $this->addExpoPushChannel($channels, $notifiable);
-        if (!$notifiable->notify_expense_sheet_to_approval) {
+        if (! $notifiable->notify_expense_sheet_to_approval) {
             return [];
         }
 
@@ -45,7 +46,7 @@ class ExpenseSheetToApproval extends Notification implements ShouldQueue
             ->greeting('Bonjour,')
             ->line("Une nouvelle note de frais a été soumise par : **{$this->sheet->user->name}**.")
             ->line("Date de création : {$this->sheet->created_at->format('d/m/Y')}")
-            ->action('Voir la note de frais', url("/expense-sheet/{$this->sheet->id}"))
+            ->action('Voir la note de frais', $this->organizationUrl($this->sheet->organization, "/expense-sheet/{$this->sheet->id}"))
             ->line('Merci de valider ou refuser cette note dès que possible.');
     }
 

--- a/app/Notifications/ReceiptExpenseSheet.php
+++ b/app/Notifications/ReceiptExpenseSheet.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\ExpenseSheet;
+use App\Notifications\Concerns\LinksToOrganization;
 use App\Notifications\Concerns\SendsExpoPushNotifications;
 use App\Notifications\Messages\ExpoPushMessage;
 use Illuminate\Bus\Queueable;
@@ -12,7 +13,7 @@ use Illuminate\Notifications\Notification;
 
 class ReceiptExpenseSheet extends Notification implements ShouldQueue
 {
-    use Queueable, SendsExpoPushNotifications;
+    use LinksToOrganization, Queueable, SendsExpoPushNotifications;
 
     public ExpenseSheet $expenseSheet;
 
@@ -50,7 +51,7 @@ class ReceiptExpenseSheet extends Notification implements ShouldQueue
             ->subject('Nouvelle note de frais reçue')
             ->greeting('Bonjour,')
             ->line('Nous avons bien reçu votre note de frais.')
-            ->action('Voir la note de frais', url('/expense-sheet/'.$this->expenseSheet->id))
+            ->action('Voir la note de frais', $this->organizationUrl($this->expenseSheet->organization, '/expense-sheet/'.$this->expenseSheet->id))
             ->line('Merci d\'utiliser notre application !')
             ->salutation('Bien cordialement,');
     }

--- a/app/Notifications/ReceiptExpenseSheetForUser.php
+++ b/app/Notifications/ReceiptExpenseSheetForUser.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\ExpenseSheet;
+use App\Notifications\Concerns\LinksToOrganization;
 use App\Notifications\Concerns\SendsExpoPushNotifications;
 use App\Notifications\Messages\ExpoPushMessage;
 use Illuminate\Bus\Queueable;
@@ -12,7 +13,7 @@ use Illuminate\Notifications\Notification;
 
 class ReceiptExpenseSheetForUser extends Notification implements ShouldQueue
 {
-    use Queueable, SendsExpoPushNotifications;
+    use LinksToOrganization, Queueable, SendsExpoPushNotifications;
 
     public ExpenseSheet $expenseSheet;
 
@@ -40,7 +41,7 @@ class ReceiptExpenseSheetForUser extends Notification implements ShouldQueue
             ->greeting("Bonjour {$notifiable->name},")
             ->line('Nous avons bien reçu la note de frais que vous avez encodée pour **'.($this->expenseSheet->user?->name ?? 'un utilisateur').'**.')
             ->line('Montant total : '.number_format($this->expenseSheet->total, 2, ',', ' ').' €')
-            ->action('Voir la note de frais', url("/expense-sheet/{$this->expenseSheet->id}"))
+            ->action('Voir la note de frais', $this->organizationUrl($this->expenseSheet->organization, "/expense-sheet/{$this->expenseSheet->id}"))
             ->line('La note de frais est en attente de validation.');
     }
 

--- a/app/Notifications/RejectionExpenseSheet.php
+++ b/app/Notifications/RejectionExpenseSheet.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\ExpenseSheet;
+use App\Notifications\Concerns\LinksToOrganization;
 use App\Notifications\Concerns\SendsExpoPushNotifications;
 use App\Notifications\Messages\ExpoPushMessage;
 use Illuminate\Bus\Queueable;
@@ -12,7 +13,7 @@ use Illuminate\Notifications\Notification;
 
 class RejectionExpenseSheet extends Notification implements ShouldQueue
 {
-    use Queueable, SendsExpoPushNotifications;
+    use LinksToOrganization, Queueable, SendsExpoPushNotifications;
 
     public ExpenseSheet $expenseSheet;
 
@@ -45,7 +46,7 @@ class RejectionExpenseSheet extends Notification implements ShouldQueue
             ->subject('Votre note de frais #'.$this->expenseSheet->id.' a été refusée')
             ->greeting('Bonjour,')
             ->line($this->expenseSheet->validatedBy->name.' a refusé votre note de frais #'.$this->expenseSheet->id)
-            ->action('Voir la note de frais', url('/expense-sheet/'.$this->expenseSheet->id))
+            ->action('Voir la note de frais', $this->organizationUrl($this->expenseSheet->organization, '/expense-sheet/'.$this->expenseSheet->id))
             ->line('Si vous pensez qu\'il s\'agit d\'une erreur, vous pouvez contacter votre responsable de service ou justifiez à nouveau votre demande.')
             ->salutation('Bien cordialement,');
     }

--- a/app/Notifications/RemindApprovalExpenseSheetNotification.php
+++ b/app/Notifications/RemindApprovalExpenseSheetNotification.php
@@ -2,7 +2,9 @@
 
 namespace App\Notifications;
 
+use App\Models\Organization;
 use App\Models\User;
+use App\Notifications\Concerns\LinksToOrganization;
 use App\Notifications\Concerns\SendsExpoPushNotifications;
 use App\Notifications\Messages\ExpoPushMessage;
 use Illuminate\Bus\Queueable;
@@ -12,19 +14,22 @@ use Illuminate\Notifications\Notification;
 
 class RemindApprovalExpenseSheetNotification extends Notification implements ShouldQueue
 {
-    use Queueable, SendsExpoPushNotifications;
+    use LinksToOrganization, Queueable, SendsExpoPushNotifications;
 
     public int $count;
 
     public User $user;
 
+    public ?Organization $organization;
+
     /**
      * Create a new notification instance.
      */
-    public function __construct(User $user, int $count)
+    public function __construct(User $user, int $count, ?Organization $organization = null)
     {
         $this->user = $user;
         $this->count = $count;
+        $this->organization = $organization;
     }
 
     /**
@@ -53,7 +58,7 @@ class RemindApprovalExpenseSheetNotification extends Notification implements Sho
             ->subject('Rappel : Notes de frais en attente de validation')
             ->greeting('Bonjour,')
             ->line('Vous avez encore '.$this->count.' note(s) de frais à valider.')
-            ->action('Voir les notes de frais', url('/dashboard'))
+            ->action('Voir les notes de frais', $this->organizationUrl($this->organization, '/dashboard'))
             ->line('Merci de traiter ces demandes dès que possible.')
             ->salutation('Bien cordialement,');
     }

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -2,23 +2,27 @@
 
 namespace App\Notifications;
 
+use App\Models\Organization;
+use App\Notifications\Concerns\LinksToOrganization;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
 class ResetPasswordNotification extends Notification
 {
-    use Queueable;
+    use LinksToOrganization, Queueable;
 
     public string $token;
+
+    public ?Organization $organization;
 
     /**
      * Create a new notification instance.
      */
-    public function __construct(string $token)
+    public function __construct(string $token, ?Organization $organization = null)
     {
         $this->token = $token;
+        $this->organization = $organization;
     }
 
     /**
@@ -36,19 +40,18 @@ class ResetPasswordNotification extends Notification
      */
     public function toMail($notifiable)
     {
-        $url = url(route('password.reset', [
+        $url = $this->organizationUrl($this->organization, route('password.reset', [
             'token' => $this->token,
             'email' => $notifiable->getEmailForPasswordReset(),
         ], false));
 
-        return (new \Illuminate\Notifications\Messages\MailMessage)
+        return (new MailMessage)
             ->subject('Réinitialisation de votre mot de passe')
             ->greeting('Bonjour,')
             ->line('Vous recevez cet e-mail car nous avons reçu une demande de réinitialisation de mot de passe pour votre compte.')
             ->action('Réinitialiser le mot de passe', $url)
             ->line('Si vous n\'avez pas demandé de réinitialisation, aucune action n\'est requise.');
     }
-
 
     /**
      * Get the array representation of the notification.

--- a/app/Notifications/SRHReturnExpenseSheet.php
+++ b/app/Notifications/SRHReturnExpenseSheet.php
@@ -3,6 +3,7 @@
 namespace App\Notifications;
 
 use App\Models\ExpenseSheet;
+use App\Notifications\Concerns\LinksToOrganization;
 use App\Notifications\Concerns\SendsExpoPushNotifications;
 use App\Notifications\Messages\ExpoPushMessage;
 use Illuminate\Bus\Queueable;
@@ -12,7 +13,7 @@ use Illuminate\Notifications\Notification;
 
 class SRHReturnExpenseSheet extends Notification implements ShouldQueue
 {
-    use Queueable, SendsExpoPushNotifications;
+    use LinksToOrganization, Queueable, SendsExpoPushNotifications;
 
     public ExpenseSheet $expenseSheet;
 
@@ -51,7 +52,7 @@ class SRHReturnExpenseSheet extends Notification implements ShouldQueue
         }
 
         return $message
-            ->action('Voir la note de frais', url('/expense-sheet/'.$this->expenseSheet->id))
+            ->action('Voir la note de frais', $this->organizationUrl($this->expenseSheet->organization, '/expense-sheet/'.$this->expenseSheet->id))
             ->line('Veuillez prendre les mesures nécessaires pour corriger cette note de frais.')
             ->salutation('Bien cordialement,');
     }

--- a/app/Notifications/UserCreated.php
+++ b/app/Notifications/UserCreated.php
@@ -2,6 +2,8 @@
 
 namespace App\Notifications;
 
+use App\Models\Organization;
+use App\Notifications\Concerns\LinksToOrganization;
 use App\Notifications\Concerns\SendsExpoPushNotifications;
 use App\Notifications\Messages\ExpoPushMessage;
 use Illuminate\Bus\Queueable;
@@ -11,7 +13,7 @@ use Illuminate\Notifications\Notification;
 
 class UserCreated extends Notification implements ShouldQueue
 {
-    use Queueable, SendsExpoPushNotifications;
+    use LinksToOrganization, Queueable, SendsExpoPushNotifications;
 
     /**
      * Create a new notification instance.
@@ -20,10 +22,13 @@ class UserCreated extends Notification implements ShouldQueue
 
     private string $email;
 
-    public function __construct(string $token, string $email)
+    private ?Organization $organization;
+
+    public function __construct(string $token, string $email, ?Organization $organization = null)
     {
         $this->token = $token;
         $this->email = $email;
+        $this->organization = $organization;
     }
 
     /**
@@ -47,7 +52,7 @@ class UserCreated extends Notification implements ShouldQueue
             ->subject('Création de compte sur la plateforme de gestion des notes de frais')
             ->greeting('Bonjour ,')
             ->line('Nous vous informons que votre compte a été créé avec succès.')
-            ->action('Réinitialiser le mot de passe', url('/reset-password/'.$this->token.'?email='.$this->email))
+            ->action('Réinitialiser le mot de passe', $this->organizationUrl($this->organization, '/reset-password/'.$this->token.'?email='.$this->email))
             ->line('Cette application vous permet de gérer vos notes de frais de manière plus efficace.')
             ->line('Merci d\'utiliser notre application !')
             ->salutation('Cordialement,');

--- a/tests/Feature/OrganizationNotificationUrlTest.php
+++ b/tests/Feature/OrganizationNotificationUrlTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ExpenseSheet;
+use App\Models\Organization;
+use App\Models\User;
+use App\Notifications\ReceiptExpenseSheet;
+use App\Notifications\UserCreated;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class OrganizationNotificationUrlTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.url' => 'https://snapfrais.be']);
+        URL::forceRootUrl('https://snapfrais.be');
+    }
+
+    public function test_organization_url_uses_custom_domain_when_set(): void
+    {
+        $organization = Organization::factory()->make(['domain' => 'frais.cpas-andenne.be']);
+
+        $this->assertSame('https://frais.cpas-andenne.be/dashboard', $organization->url('/dashboard'));
+    }
+
+    public function test_organization_url_falls_back_to_subdomain(): void
+    {
+        $organization = Organization::factory()->make(['slug' => 'ville', 'domain' => null]);
+
+        $this->assertSame('https://ville.snapfrais.be/dashboard', $organization->url('/dashboard'));
+    }
+
+    public function test_expense_sheet_notification_links_to_the_sheet_organization(): void
+    {
+        $organization = Organization::factory()->create(['slug' => 'cpas', 'domain' => 'frais.cpas-andenne.be']);
+        $sheet = ExpenseSheet::factory()->create(['organization_id' => $organization->id]);
+
+        $mail = (new ReceiptExpenseSheet($sheet))->toMail($sheet->user);
+
+        $this->assertSame('https://frais.cpas-andenne.be/expense-sheet/'.$sheet->id, $mail->actionUrl);
+    }
+
+    public function test_account_notification_links_to_the_provided_organization(): void
+    {
+        $organization = Organization::factory()->create(['slug' => 'ville', 'domain' => null]);
+        $user = User::factory()->create();
+
+        $mail = (new UserCreated('tok', 'agent@ville.be', $organization))->toMail($user);
+
+        $this->assertSame('https://ville.snapfrais.be/reset-password/tok?email=agent@ville.be', $mail->actionUrl);
+    }
+
+    public function test_notification_falls_back_to_app_url_without_organization(): void
+    {
+        $sheet = ExpenseSheet::factory()->create(['organization_id' => null]);
+
+        $mail = (new ReceiptExpenseSheet($sheet))->toMail($sheet->user);
+
+        $this->assertSame(url('/expense-sheet/'.$sheet->id), $mail->actionUrl);
+    }
+}


### PR DESCRIPTION
## Résumé

Complément au multi-tenant (déjà mergé via #120) : les **liens contenus dans les mails** pointaient tous vers le domaine nu (`APP_URL`), identique pour Ville et CPAS.

En cause : toutes les notifications sont `ShouldQueue`, donc exécutées **sans requête HTTP** — `url()` retombe sur `config('app.url')` et ne connaît pas l'organisation du destinataire.

## Changements

- `Organization::url()` / `baseUrl()` : construit une URL absolue sur le host de l'org (son `domain` custom, sinon `{slug}.{APP_URL}`).
- Trait `LinksToOrganization` : `organizationUrl(?Organization, $path)`, avec repli propre sur `url()` quand l'organisation est inconnue (données historiques sans org).
- **6 notifications de note de frais** : le lien est dérivé de l'organisation de la note (`$sheet->organization`), sans toucher aux points d'envoi.
- **Rappel de validation** : le job groupe désormais les notes **par organisation** → un rappel par org, chacun vers le bon dashboard.
- **UserCreated / AdminInitiatedPasswordReset / ResetPasswordNotification** : reçoivent l'organisation courante au moment de l'envoi (reset self-service = domaine depuis lequel la demande est faite).

## Tests

Suite complète verte (**173 tests**), dont un nouveau fichier couvrant : `Organization::url()` (domaine custom + repli sous-domaine), le lien d'une notif de note de frais vers l'org de la note, le lien d'une notif de compte vers l'org fournie, et le repli sur `APP_URL` sans organisation.

## Points connus non traités (inchangés)

- Résolution par sous-domaine non appliquée à l'API mobile (`routes/api.php`, Sanctum).
- Rattachement d'org non automatique pour l'import Excel (`UsersImport`) et l'inscription (`RegisteredUserController`) → dans ces cas, les liens de mail retombent sur `APP_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)