### PR TITLE
Multi-tenant par organisation + switch d'org (Ville/CPAS)

### DIFF
--- a/app/Http/Controllers/OrganizationSwitchController.php
+++ b/app/Http/Controllers/OrganizationSwitchController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Middleware\ResolveOrganization;
+use App\Models\Organization;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class OrganizationSwitchController extends Controller
+{
+    /**
+     * Switch the active organization for a super_admin, persisting the choice in
+     * the session so it survives across requests without changing the URL.
+     */
+    public function update(Request $request, Organization $organization): RedirectResponse
+    {
+        abort_unless((bool) $request->user()?->super_admin, 403);
+
+        $request->session()->put(ResolveOrganization::SESSION_KEY, $organization->getKey());
+
+        return back(fallback: route('dashboard'))
+            ->with('success', "Organisation active : {$organization->organization_name}.");
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use App\Models\Department;
 use App\Models\Form;
+use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Http\Request;
@@ -48,10 +49,12 @@ class HandleInertiaRequests extends Middleware
             ...parent::share($request),
             'name' => config('app.name'),
             'organization' => $organization === null ? null : [
+                'id' => $organization->id,
                 'name' => $organization->name,
                 'slug' => $organization->slug,
                 'organizationName' => $organization->organization_name,
             ],
+            'organizationSwitcher' => $this->organizationSwitcher($request->user(), $organization),
             'quote' => ['message' => trim($message), 'author' => trim($author)],
             'auth' => [
                 'user' => $request->user(),
@@ -71,6 +74,32 @@ class HandleInertiaRequests extends Middleware
                 'warning' => fn () => session()->get('warning'),
                 'info' => fn () => session()->get('info'),
             ],
+        ];
+    }
+
+    /**
+     * Organization switcher payload shared with super_admins only, letting them
+     * change the active organization without changing the URL. Returns null for
+     * every other user.
+     *
+     * @return array{current: int|null, options: list<array{id: int, organizationName: string}>}|null
+     */
+    protected function organizationSwitcher(?User $user, ?Organization $organization): ?array
+    {
+        if ($user === null || ! $user->super_admin) {
+            return null;
+        }
+
+        return [
+            'current' => $organization?->id,
+            'options' => Organization::query()
+                ->orderBy('organization_name')
+                ->get(['id', 'organization_name'])
+                ->map(fn (Organization $org): array => [
+                    'id' => $org->id,
+                    'organizationName' => $org->organization_name,
+                ])
+                ->all(),
         ];
     }
 }

--- a/app/Http/Middleware/ResolveOrganization.php
+++ b/app/Http/Middleware/ResolveOrganization.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use App\Models\Organization;
+use App\Models\User;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -11,12 +12,20 @@ use Symfony\Component\HttpFoundation\Response;
 class ResolveOrganization
 {
     /**
+     * Session key holding the organization a super_admin switched to, letting
+     * them operate on another organization without changing the request host.
+     */
+    public const SESSION_KEY = 'active_organization_id';
+
+    /**
      * Resolve the current organization from the request subdomain, bind it for
      * the request lifecycle, and ensure the authenticated user belongs to it.
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $organization = $this->resolveOrganization($request);
+        $user = $request->user();
+
+        $organization = $this->resolveActiveOrganization($request, $user);
 
         if ($organization === null) {
             return $next($request);
@@ -24,13 +33,50 @@ class ResolveOrganization
 
         setCurrentOrganization($organization);
 
-        $user = $request->user();
-
         if ($user !== null && ! $user->super_admin && ! $user->belongsToOrganization($organization)) {
             abort(403, "Vous n'avez pas accès à cette organisation.");
         }
 
         return $next($request);
+    }
+
+    /**
+     * Determine the active organization for the request. A super_admin's session
+     * override takes precedence — it is how they switch organization without
+     * changing the URL — otherwise the organization is resolved from the host.
+     */
+    private function resolveActiveOrganization(Request $request, ?User $user): ?Organization
+    {
+        if ($user?->super_admin) {
+            $override = $this->resolveOverride($request);
+
+            if ($override !== null) {
+                return $override;
+            }
+        }
+
+        return $this->resolveOrganization($request);
+    }
+
+    /**
+     * Resolve the organization a super_admin switched to, clearing the session
+     * key if it points to an organization that no longer exists.
+     */
+    private function resolveOverride(Request $request): ?Organization
+    {
+        $overrideId = $request->session()->get(self::SESSION_KEY);
+
+        if ($overrideId === null) {
+            return null;
+        }
+
+        $organization = Organization::find($overrideId);
+
+        if ($organization === null) {
+            $request->session()->forget(self::SESSION_KEY);
+        }
+
+        return $organization;
     }
 
     /**

--- a/resources/js/components/AppLogo.vue
+++ b/resources/js/components/AppLogo.vue
@@ -1,5 +1,18 @@
 <script setup lang="ts">
 import AppLogoIcon from '@/components/AppLogoIcon.vue';
+import { type SharedData } from '@/types';
+import { usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+const page = usePage<SharedData>();
+
+const label = computed<string>(() => {
+    const user = page.props.auth?.user;
+    const isAdmin = Boolean(user?.is_admin || user?.super_admin);
+    const organizationName = page.props.organization?.organizationName;
+
+    return isAdmin && organizationName ? organizationName : 'SnapFrais';
+});
 </script>
 
 <template>
@@ -7,6 +20,6 @@ import AppLogoIcon from '@/components/AppLogoIcon.vue';
         <AppLogoIcon class="size-5 fill-current text-white dark:text-black" />
     </div>
     <div class="ml-1 grid flex-1 text-left text-sm sm:text-base">
-        <span class="mb-0.5 truncate font-semibold leading-none">SnapFrais</span>
+        <span class="mb-0.5 truncate font-semibold leading-none">{{ label }}</span>
     </div>
 </template>

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -15,10 +15,13 @@ import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/vue3';
 import { BarChart3, BookOpen, Building2, FileText, Folder, LayoutGrid, Library, ScrollText, Users } from 'lucide-vue-next';
 import AppLogo from './AppLogo.vue';
+import OrgSwitcher from './OrgSwitcher.vue';
 
+import { type SharedData } from '@/types';
 import { usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
 
-const page = usePage();
+const page = usePage<SharedData>();
 const can = page.props.auth.can as {
     departments: boolean;
     users: boolean;
@@ -27,6 +30,8 @@ const can = page.props.auth.can as {
 };
 
 const isAdmin = page.props.auth.user?.is_admin || false;
+
+const canSwitchOrganization = computed<boolean>(() => (page.props.organizationSwitcher?.options.length ?? 0) > 1);
 
 
 const mainNavItems: NavItem[] = [
@@ -87,7 +92,8 @@ const footerNavItems: NavItem[] = [
         <SidebarHeader>
             <SidebarMenu>
                 <SidebarMenuItem>
-                    <SidebarMenuButton size="lg" as-child>
+                    <OrgSwitcher v-if="canSwitchOrganization" />
+                    <SidebarMenuButton v-else size="lg" as-child>
                         <Link :href="route('dashboard')">
                             <AppLogo />
                         </Link>

--- a/resources/js/components/OrgSwitcher.vue
+++ b/resources/js/components/OrgSwitcher.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import AppLogo from '@/components/AppLogo.vue';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { SidebarMenuButton, useSidebar } from '@/components/ui/sidebar';
+import { type OrganizationSwitcher, type SharedData } from '@/types';
+import { router, usePage } from '@inertiajs/vue3';
+import { Check, ChevronsUpDown } from 'lucide-vue-next';
+import { computed } from 'vue';
+
+const page = usePage<SharedData>();
+const { isMobile, state } = useSidebar();
+
+const switcher = computed<OrganizationSwitcher | null>(() => page.props.organizationSwitcher);
+
+function switchTo(id: number): void {
+    if (id === switcher.value?.current) {
+        return;
+    }
+
+    router.post(route('organizations.switch', id), {}, { preserveScroll: true });
+}
+</script>
+
+<template>
+    <DropdownMenu v-if="switcher">
+        <DropdownMenuTrigger as-child>
+            <SidebarMenuButton size="lg" class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground">
+                <AppLogo />
+                <ChevronsUpDown class="ml-auto size-4" />
+            </SidebarMenuButton>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+            class="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+            :side="isMobile ? 'bottom' : state === 'collapsed' ? 'right' : 'bottom'"
+            align="start"
+            :side-offset="4"
+        >
+            <DropdownMenuLabel class="text-xs text-muted-foreground">Organisations</DropdownMenuLabel>
+            <DropdownMenuItem
+                v-for="option in switcher.options"
+                :key="option.id"
+                class="cursor-pointer"
+                @select="switchTo(option.id)"
+            >
+                <span class="truncate">{{ option.organizationName }}</span>
+                <Check v-if="option.id === switcher.current" class="ml-auto size-4" />
+            </DropdownMenuItem>
+        </DropdownMenuContent>
+    </DropdownMenu>
+</template>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -18,10 +18,24 @@ export interface NavItem {
     isActive?: boolean;
 }
 
+export interface Organization {
+    id: number;
+    name: string;
+    slug: string;
+    organizationName: string;
+}
+
+export interface OrganizationSwitcher {
+    current: number | null;
+    options: Array<{ id: number; organizationName: string }>;
+}
+
 export interface SharedData extends PageProps {
     name: string;
     quote: { message: string; author: string };
     auth: Auth;
+    organization: Organization | null;
+    organizationSwitcher: OrganizationSwitcher | null;
     ziggy: Config & { location: string };
 }
 
@@ -31,6 +45,8 @@ export interface User {
     email: string;
     avatar?: string;
     email_verified_at: string | null;
+    is_admin?: boolean;
+    super_admin?: boolean;
     notify_expense_sheet_to_approval?: boolean;
     notify_receipt_expense_sheet?: boolean;
     notify_remind_approval?: boolean;

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\ActivityLogController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\DepartmentController;
 use App\Http\Controllers\ImpersonationController;
+use App\Http\Controllers\OrganizationSwitchController;
 use App\Http\Controllers\PatchNoteController;
 use App\Http\Controllers\StatisticsController;
 use App\Http\Controllers\TermsAcceptanceController;
@@ -52,6 +53,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/admin/statistics', [StatisticsController::class, 'index'])->name('statistics.index');
 });
+
+// Organization switching (super_admin only)
+Route::post('/organizations/switch/{organization}', [OrganizationSwitchController::class, 'update'])
+    ->middleware(['auth', 'verified'])
+    ->name('organizations.switch');
 
 // Impersonation routes
 Route::middleware(['auth', 'verified'])->group(function () {

--- a/tests/Feature/OrganizationSwitchTest.php
+++ b/tests/Feature/OrganizationSwitchTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\ResolveOrganization;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OrganizationSwitchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.url' => 'http://snapfrais.test']);
+    }
+
+    protected function tearDown(): void
+    {
+        setCurrentOrganization(null);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Build a URL on the given organization subdomain.
+     */
+    private function on(string $slug, string $routeName, array $params = []): string
+    {
+        return "http://{$slug}.snapfrais.test".route($routeName, $params, absolute: false);
+    }
+
+    public function test_super_admin_can_switch_organization_without_changing_url(): void
+    {
+        $ville = Organization::factory()->create(['slug' => 'ville']);
+        $cpas = Organization::factory()->create(['slug' => 'cpas', 'organization_name' => 'CPAS de Test']);
+        $super = User::factory()->create(['super_admin' => true]);
+
+        $this->actingAs($super)
+            ->post(route('organizations.switch', $cpas))
+            ->assertSessionHas(ResolveOrganization::SESSION_KEY, $cpas->id);
+
+        // Even while browsing the "ville" subdomain, the session override wins.
+        $this->actingAs($super)
+            ->get($this->on('ville', 'dashboard'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('organization.slug', 'cpas')
+                ->where('organization.organizationName', 'CPAS de Test')
+            );
+    }
+
+    public function test_super_admin_receives_switcher_options(): void
+    {
+        Organization::factory()->create(['slug' => 'ville', 'organization_name' => 'Ville de Test']);
+        Organization::factory()->create(['slug' => 'cpas', 'organization_name' => 'CPAS de Test']);
+        $super = User::factory()->create(['super_admin' => true]);
+
+        $this->actingAs($super)
+            ->get($this->on('ville', 'dashboard'))
+            ->assertInertia(fn ($page) => $page
+                ->where('organizationSwitcher.current', fn ($current) => $current !== null)
+                ->has('organizationSwitcher.options', 2)
+            );
+    }
+
+    public function test_non_super_admin_cannot_switch_organization(): void
+    {
+        $ville = Organization::factory()->create(['slug' => 'ville']);
+        $cpas = Organization::factory()->create(['slug' => 'cpas']);
+        $admin = User::factory()->create(['is_admin' => true, 'super_admin' => false]);
+        $admin->organizations()->attach($ville);
+
+        $this->actingAs($admin)
+            ->post(route('organizations.switch', $cpas))
+            ->assertForbidden();
+
+        $this->assertNull(session(ResolveOrganization::SESSION_KEY));
+    }
+
+    public function test_non_super_admin_does_not_receive_switcher(): void
+    {
+        $ville = Organization::factory()->create(['slug' => 'ville']);
+        $admin = User::factory()->create(['is_admin' => true, 'super_admin' => false]);
+        $admin->organizations()->attach($ville);
+
+        $this->actingAs($admin)
+            ->get($this->on('ville', 'dashboard'))
+            ->assertInertia(fn ($page) => $page->where('organizationSwitcher', null));
+    }
+
+    public function test_stale_override_falls_back_to_host_organization(): void
+    {
+        $ville = Organization::factory()->create(['slug' => 'ville', 'organization_name' => 'Ville de Test']);
+        $super = User::factory()->create(['super_admin' => true]);
+
+        $this->actingAs($super)
+            ->withSession([ResolveOrganization::SESSION_KEY => 999999])
+            ->get($this->on('ville', 'dashboard'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->where('organization.slug', 'ville'));
+    }
+}


### PR DESCRIPTION
## Résumé

PR de `developpement` vers `main` regroupant le chantier **multi-tenant par organisation** (fusion des déploiements Ville et CPAS en une seule base) et les correctifs associés.

### Multi-tenant organisation
- Introduction de la notion `Organization` (relation many-to-many `User ↔ Organization`).
- Résolution de l'org active **par sous-domaine** (`ville.…` / `cpas.…`) ou **domaine complet** custom, via le middleware `ResolveOrganization`.
- Cloisonnement des données (`Department`/`Form`/`ExpenseSheet`/…) via un global scope ; `super_admin` transverse.
- Liens des mails (notifications en file d'attente) construits selon l'organisation.

### Switch d'organisation (super_admin)
- Affichage du nom de l'organisation (au lieu de « SnapFrais ») en haut à gauche pour les admins.
- Sélecteur d'organisation dans la sidebar, **réservé aux super_admin**, qui bascule l'org active **sans changer d'URL** (override stocké en session, prioritaire sur le sous-domaine).

### Autres correctifs inclus
- Notification de rappel de validation mise en file d'attente (`ShouldQueue`).
- Factorisation du scope « notes à valider ».
- Restriction de l'historique des exports aux utilisateurs autorisés.

## Tests
- Suites `OrganizationTenancyTest`, `OrganizationSwitchTest`, `OrganizationNotificationUrlTest`, `ImportSourceOrganizationTest` vertes ; Pint et `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)