### PR TITLE
Étend le switch d'organisation aux simples admins

### DIFF
--- a/app/Http/Controllers/OrganizationSwitchController.php
+++ b/app/Http/Controllers/OrganizationSwitchController.php
@@ -10,12 +10,15 @@ use Illuminate\Http\Request;
 class OrganizationSwitchController extends Controller
 {
     /**
-     * Switch the active organization for a super_admin, persisting the choice in
-     * the session so it survives across requests without changing the URL.
+     * Switch the active organization, persisting the choice in the session so it
+     * survives across requests without changing the URL. A super_admin may reach
+     * any organization; a platform admin only the ones they belong to.
      */
     public function update(Request $request, Organization $organization): RedirectResponse
     {
-        abort_unless((bool) $request->user()?->super_admin, 403);
+        $user = $request->user();
+
+        abort_unless($user !== null && $user->canSwitchToOrganization($organization), 403);
 
         $request->session()->put(ResolveOrganization::SESSION_KEY, $organization->getKey());
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -78,28 +78,33 @@ class HandleInertiaRequests extends Middleware
     }
 
     /**
-     * Organization switcher payload shared with super_admins only, letting them
-     * change the active organization without changing the URL. Returns null for
-     * every other user.
+     * Organization switcher payload shared with admins, letting them change the
+     * active organization without changing the URL. A super_admin gets every
+     * organization; a platform admin only their own. Null for everyone else.
      *
      * @return array{current: int|null, options: list<array{id: int, organizationName: string}>}|null
      */
     protected function organizationSwitcher(?User $user, ?Organization $organization): ?array
     {
-        if ($user === null || ! $user->super_admin) {
+        if ($user === null || ! $user->canSwitchOrganizations()) {
+            return null;
+        }
+
+        $options = $user->switchableOrganizations()
+            ->map(fn (Organization $org): array => [
+                'id' => $org->id,
+                'organizationName' => $org->organization_name,
+            ])
+            ->values()
+            ->all();
+
+        if (count($options) < 2) {
             return null;
         }
 
         return [
             'current' => $organization?->id,
-            'options' => Organization::query()
-                ->orderBy('organization_name')
-                ->get(['id', 'organization_name'])
-                ->map(fn (Organization $org): array => [
-                    'id' => $org->id,
-                    'organizationName' => $org->organization_name,
-                ])
-                ->all(),
+            'options' => $options,
         ];
     }
 }

--- a/app/Http/Middleware/ResolveOrganization.php
+++ b/app/Http/Middleware/ResolveOrganization.php
@@ -41,14 +41,14 @@ class ResolveOrganization
     }
 
     /**
-     * Determine the active organization for the request. A super_admin's session
-     * override takes precedence — it is how they switch organization without
+     * Determine the active organization for the request. A switched-to session
+     * override takes precedence — it is how an admin changes organization without
      * changing the URL — otherwise the organization is resolved from the host.
      */
     private function resolveActiveOrganization(Request $request, ?User $user): ?Organization
     {
-        if ($user?->super_admin) {
-            $override = $this->resolveOverride($request);
+        if ($user !== null) {
+            $override = $this->resolveOverride($request, $user);
 
             if ($override !== null) {
                 return $override;
@@ -59,10 +59,11 @@ class ResolveOrganization
     }
 
     /**
-     * Resolve the organization a super_admin switched to, clearing the session
-     * key if it points to an organization that no longer exists.
+     * Resolve the organization the user switched to, honouring it only when the
+     * user is still allowed to reach it, and clearing a stale or forbidden
+     * override so the request falls back to the host organization.
      */
-    private function resolveOverride(Request $request): ?Organization
+    private function resolveOverride(Request $request, User $user): ?Organization
     {
         $overrideId = $request->session()->get(self::SESSION_KEY);
 
@@ -72,8 +73,10 @@ class ResolveOrganization
 
         $organization = Organization::find($overrideId);
 
-        if ($organization === null) {
+        if ($organization === null || ! $user->canSwitchToOrganization($organization)) {
             $request->session()->forget(self::SESSION_KEY);
+
+            return null;
         }
 
         return $organization;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Laravel\Sanctum\HasApiTokens;
 use Mirror\Concerns\Impersonatable;
 use Spatie\Activitylog\LogOptions;
@@ -105,6 +106,47 @@ class User extends Authenticatable implements HasPasskeysContract
         return $this->organizations()
             ->whereKey($organization->getKey())
             ->exists();
+    }
+
+    /**
+     * Determine whether the user may switch the active organization at all: a
+     * super_admin can, and so can a platform admin who belongs to several.
+     */
+    public function canSwitchOrganizations(): bool
+    {
+        return (bool) $this->super_admin || (bool) $this->is_admin;
+    }
+
+    /**
+     * Organizations the user may switch the active context to: every organization
+     * for a super_admin, only their own memberships for a platform admin.
+     *
+     * @return Collection<int, Organization>
+     */
+    public function switchableOrganizations(): Collection
+    {
+        if ($this->super_admin) {
+            return Organization::query()->orderBy('organization_name')->get();
+        }
+
+        if ($this->is_admin) {
+            return $this->organizations()->orderBy('organization_name')->get();
+        }
+
+        return collect();
+    }
+
+    /**
+     * Determine whether the user may switch the active context to the given
+     * organization.
+     */
+    public function canSwitchToOrganization(Organization $organization): bool
+    {
+        if ($this->super_admin) {
+            return true;
+        }
+
+        return (bool) $this->is_admin && $this->belongsToOrganization($organization);
     }
 
     /**

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -31,7 +31,7 @@ const can = page.props.auth.can as {
 
 const isAdmin = page.props.auth.user?.is_admin || false;
 
-const canSwitchOrganization = computed<boolean>(() => (page.props.organizationSwitcher?.options.length ?? 0) > 1);
+const canSwitchOrganization = computed<boolean>(() => page.props.organizationSwitcher !== null);
 
 
 const mainNavItems: NavItem[] = [

--- a/tests/Feature/OrganizationSwitchTest.php
+++ b/tests/Feature/OrganizationSwitchTest.php
@@ -68,7 +68,41 @@ class OrganizationSwitchTest extends TestCase
             );
     }
 
-    public function test_non_super_admin_cannot_switch_organization(): void
+    public function test_platform_admin_can_switch_among_their_own_organizations(): void
+    {
+        $ville = Organization::factory()->create(['slug' => 'ville']);
+        $cpas = Organization::factory()->create(['slug' => 'cpas', 'organization_name' => 'CPAS de Test']);
+        $admin = User::factory()->create(['is_admin' => true, 'super_admin' => false]);
+        $admin->organizations()->attach([$ville->id, $cpas->id]);
+
+        $this->actingAs($admin)
+            ->post(route('organizations.switch', $cpas))
+            ->assertSessionHas(ResolveOrganization::SESSION_KEY, $cpas->id);
+
+        $this->actingAs($admin)
+            ->get($this->on('ville', 'dashboard'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->where('organization.slug', 'cpas'));
+    }
+
+    public function test_platform_admin_only_sees_their_own_organizations_in_switcher(): void
+    {
+        $ville = Organization::factory()->create(['slug' => 'ville', 'organization_name' => 'Ville de Test']);
+        $cpas = Organization::factory()->create(['slug' => 'cpas', 'organization_name' => 'CPAS de Test']);
+        Organization::factory()->create(['slug' => 'autre', 'organization_name' => 'Autre Org']);
+        $admin = User::factory()->create(['is_admin' => true, 'super_admin' => false]);
+        $admin->organizations()->attach([$ville->id, $cpas->id]);
+
+        $this->actingAs($admin)
+            ->get($this->on('ville', 'dashboard'))
+            ->assertInertia(fn ($page) => $page
+                ->has('organizationSwitcher.options', 2)
+                ->where('organizationSwitcher.options.0.organizationName', 'CPAS de Test')
+                ->where('organizationSwitcher.options.1.organizationName', 'Ville de Test')
+            );
+    }
+
+    public function test_platform_admin_cannot_switch_to_a_foreign_organization(): void
     {
         $ville = Organization::factory()->create(['slug' => 'ville']);
         $cpas = Organization::factory()->create(['slug' => 'cpas']);
@@ -82,13 +116,25 @@ class OrganizationSwitchTest extends TestCase
         $this->assertNull(session(ResolveOrganization::SESSION_KEY));
     }
 
-    public function test_non_super_admin_does_not_receive_switcher(): void
+    public function test_single_organization_admin_does_not_receive_switcher(): void
     {
         $ville = Organization::factory()->create(['slug' => 'ville']);
         $admin = User::factory()->create(['is_admin' => true, 'super_admin' => false]);
         $admin->organizations()->attach($ville);
 
         $this->actingAs($admin)
+            ->get($this->on('ville', 'dashboard'))
+            ->assertInertia(fn ($page) => $page->where('organizationSwitcher', null));
+    }
+
+    public function test_regular_user_does_not_receive_switcher(): void
+    {
+        $ville = Organization::factory()->create(['slug' => 'ville']);
+        Organization::factory()->create(['slug' => 'cpas']);
+        $user = User::factory()->create(['is_admin' => false, 'super_admin' => false]);
+        $user->organizations()->attach($ville);
+
+        $this->actingAs($user)
             ->get($this->on('ville', 'dashboard'))
             ->assertInertia(fn ($page) => $page->where('organizationSwitcher', null));
     }


### PR DESCRIPTION
## Résumé

Fait suite à #122 (mergée). Étend le sélecteur d'organisation, jusqu'ici réservé aux `super_admin`, aux **administrateurs de plateforme** (`is_admin`).

## Comportement

| Rôle | Voit le nom d'org | Peut switcher | Vers quelles orgs |
|------|:---:|:---:|---|
| **super_admin** | ✅ | ✅ | toutes les organisations |
| **admin** (`is_admin`) | ✅ | ✅ | uniquement ses organisations membres |
| utilisateur lambda | ❌ | ❌ | — |

Le sélecteur n'est affiché que s'il existe au moins deux organisations cibles.

## Sécurité

Logique centralisée sur `User` (`canSwitchOrganizations`, `switchableOrganizations`, `canSwitchToOrganization`) et appliquée des deux côtés :
- le contrôleur refuse (403) un switch vers une organisation non autorisée ;
- le middleware `ResolveOrganization` n'honore l'override en session que si l'utilisateur y a toujours droit, sinon il nettoie la session et retombe sur l'organisation du sous-domaine.

## Tests
- `OrganizationSwitchTest` : 8 cas verts (switch admin entre ses orgs, périmètre limité à ses orgs, refus sur org étrangère, admin mono-org sans switcher, user lambda sans switcher, override périmé).
- `OrganizationTenancyTest` : 7 verts (pas de régression). Pint + `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)